### PR TITLE
Makes pbdirect cross scala versioned with 2.11.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ dist: trusty
 language: scala
 jdk: openjdk8
 scala:
+    - 2.11.11
     - 2.12.2
 
 script:

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,8 @@ version := "0.0.3"
 
 scalaVersion := "2.12.2"
 
+crossScalaVersions := Seq("2.11.11", "2.12.2")
+
 libraryDependencies ++= Seq(
   "com.chuusai"         %% "shapeless"     % "2.3.2",
   "org.typelevel"       %% "cats"          % "0.9.0",


### PR DESCRIPTION
This PR brings cross scala compatibility with 2.11.11. It was already compatible, I'm just enabling it ;)

Hope it makes sense. Thanks.