### PR TITLE
Enumeratum support

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -24,6 +24,7 @@ object ProjectPlugin extends AutoPlugin {
       val scala212: String  = "2.12.10"
       val scalaTest: String = "3.1.0"
       val shapeless: String = "2.3.3"
+      val enumeratum: String  = "1.5.13"
     }
   }
 
@@ -60,6 +61,7 @@ object ProjectPlugin extends AutoPlugin {
         "com.chuusai"         %% "shapeless"    % V.shapeless,
         "org.typelevel"       %% "cats-core"    % V.cats,
         "com.google.protobuf" % "protobuf-java" % V.protobuf,
+        "com.beachape"        %% "enumeratum"   % V.enumeratum,
         "org.scalatest"       %% "scalatest"    % V.scalaTest % Test
       ),
       orgScriptTaskListSetting := List(

--- a/src/main/scala/pbdirect/PBReader.scala
+++ b/src/main/scala/pbdirect/PBReader.scala
@@ -26,6 +26,7 @@ import java.io.ByteArrayOutputStream
 import cats.Functor
 import com.google.protobuf.{CodedInputStream, CodedOutputStream}
 import shapeless.{:+:, ::, CNil, Coproduct, Generic, HList, HNil, Inl, Inr, Lazy}
+import enumeratum.values.{IntEnum, IntEnumEntry}
 
 import scala.util.Try
 
@@ -75,6 +76,12 @@ trait PBReaderImplicits extends LowerPriorityPBReaderImplicits {
       gen: Generic.Aux[E, HNil]): PBReader[E#Value] = instance { (input: CodedInputStream) =>
     val enum = gen.from(HNil)
     enum(reader.read(input))
+  }
+  implicit def enumeratumIntEnumEntryReader[E <: IntEnumEntry](
+      implicit
+      reader: PBReader[Int],
+      enum: IntEnum[E]): PBReader[E] = instance { (input: CodedInputStream) =>
+    enum.withValue(reader.read(input))
   }
 }
 object PBReader extends PBReaderImplicits {

--- a/src/main/scala/pbdirect/PBWriter.scala
+++ b/src/main/scala/pbdirect/PBWriter.scala
@@ -26,6 +26,7 @@ import java.io.ByteArrayOutputStream
 import cats.{Contravariant, Functor}
 import com.google.protobuf.CodedOutputStream
 import shapeless.{:+:, ::, CNil, Coproduct, Generic, HList, HNil, Inl, Inr, Lazy}
+import enumeratum.values.IntEnumEntry
 
 trait PBWriter[A] {
   def writeTo(index: Int, value: A, out: CodedOutputStream): Unit
@@ -144,6 +145,10 @@ trait PBWriterImplicits extends LowPriorityPBWriterImplicits {
   implicit def enumerationWriter[E <: Enumeration#Value]: PBWriter[E] =
     instance { (index: Int, value: E, out: CodedOutputStream) =>
       out.writeInt32(index, value.id)
+    }
+  implicit def enumeratumIntEnumEntryWriter[E <: IntEnumEntry]: PBWriter[E] =
+    instance { (index: Int, entry: E, out: CodedOutputStream) =>
+      out.writeInt32(index, entry.value)
     }
 
   implicit object ContravariantWriter extends Contravariant[PBWriter] {

--- a/src/test/scala/pbdirect/PBReaderSpec.scala
+++ b/src/test/scala/pbdirect/PBReaderSpec.scala
@@ -23,8 +23,10 @@ package pbdirect
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
+import enumeratum.values._
 
 class PBReaderSpec extends AnyWordSpecLike with Matchers {
+
   "PBReader" should {
     "read a Boolean from Protobuf" in {
       case class BooleanMessage(value: Option[Boolean])
@@ -90,6 +92,11 @@ class PBReaderSpec extends AnyWordSpecLike with Matchers {
       val bytesB = Array[Byte](8, 1)
       bytesA.pbTo[GradeMessage] shouldBe GradeMessage(Some(GradeA))
       bytesB.pbTo[GradeMessage] shouldBe GradeMessage(Some(GradeB))
+    }
+    "read an enumeratum IntEnumEntry from Protobuf" in {
+      case class QualityMessage(quality: Quality)
+      val bytes = Array[Byte](8, 3)
+      bytes.pbTo[QualityMessage] shouldBe QualityMessage(Quality.OK)
     }
     "read a required field from Protobuf" in {
       case class RequiredMessage(value: Int)
@@ -166,4 +173,15 @@ class PBReaderSpec extends AnyWordSpecLike with Matchers {
       Array[Byte](8, -127, -55, -2, -34, -47, 43).pbTo[Message] shouldBe Message(instant)
     }
   }
+}
+
+// For some reason it fails to resolve the implicit PBReader if the enum is defined inside the test class
+sealed abstract class Quality(val value: Int) extends IntEnumEntry
+
+object Quality extends IntEnum[Quality] {
+  case object Good extends Quality(0)
+  case object OK   extends Quality(3)
+  case object Bad  extends Quality(5)
+
+  val values = findValues
 }

--- a/src/test/scala/pbdirect/PBWriterSpec.scala
+++ b/src/test/scala/pbdirect/PBWriterSpec.scala
@@ -91,6 +91,23 @@ class PBWriterSpec extends AnyWordSpecLike with Matchers {
       messageA.toPB shouldBe Array[Byte](8, 0)
       messageB.toPB shouldBe Array[Byte](8, 1)
     }
+    "write an enumeratum IntEnumEntry to Protobuf" in {
+      import enumeratum.values._
+
+      sealed abstract class Quality(val value: Int) extends IntEnumEntry
+
+      object Quality extends IntEnum[Quality] {
+        case object Good extends Quality(0)
+        case object OK   extends Quality(3)
+        case object Bad  extends Quality(5)
+
+        val values = findValues
+      }
+
+      case class QualityMessage(quality: Quality)
+      val message = QualityMessage(Quality.OK)
+      message.toPB shouldBe Array[Byte](8, 3)
+    }
     "write a required field to Protobuf" in {
       case class RequiredMessage(value: Int)
       val message = RequiredMessage(5)


### PR DESCRIPTION
Add support for reading and writing [enumeratum](https://github.com/lloydmeta/enumeratum) `IntEnum`s. These are enumerations whose elements have both a name and an integer value.

This means that in Mu we'll be able to preserve the integer values of protobuf enums. Given a `.proto` file:

```
enum Colour {
  BLUE = 0;
  RED = 5;
}
```

, instead of generating:

```scala
sealed trait Colour
object Colour {
  case object BLUE extends Colour
  case object RED extends Colour
}
```

like we currently do, we can instead encode it as:

```scala
sealed trait Colour(val value: Int) extends IntEnumEntry
object Colour extends IntEnum[Colour] {
  case object BLUE extends Colour(0)
  case object RED extends Colour(5)

  val values = findValues
}
```

This means PBDirect can encode/decode the enum using the correct integer values.

Also if https://github.com/lloydmeta/enumeratum/pull/263 gets merged and released, we will be able to handle [enums with aliases](https://developers.google.com/protocol-buffers/docs/proto3#enum).