### PR TITLE
Second attempt to remove license headers from source files

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -1,4 +1,4 @@
-import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.{headerLicense, headerCreate, HeaderLicense}
+import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
 import sbt.Keys._
 import sbt._
 import sbtorgpolicies.OrgPoliciesPlugin
@@ -54,10 +54,9 @@ object ProjectPlugin extends AutoPlugin {
         organizationEmail = "hello@47deg.com"
       ),
       orgLicenseSetting := MITLicense,
-      headerLicense := Some(
-        HeaderLicense.MIT(replaceableYear(startYear.value), "Beyond the lines")),
       // disable license headers on source files because it's too complicated, owing to us forking the project
-      excludeFilter.in(unmanagedSources.in(headerCreate)) := HiddenFileFilter || "*.*",
+      headerLicense := Some(HeaderLicense.Custom("")),
+      headerMappings := headerMappings.value + (HeaderFileType.scala -> HeaderCommentStyle.CppStyleLineComment),
       startYear := Some(2019),
       scalaVersion := V.scala212,
       crossScalaVersions := Seq(scalaVersion.value, V.scala211),


### PR DESCRIPTION
The previous attempt accidentally excluding the files from compilation as well. This time we keep the header but make it a blank string.