### PR TITLE
Support for scalar default values

### DIFF
--- a/src/main/scala/pbdirect/PBFieldReader.scala
+++ b/src/main/scala/pbdirect/PBFieldReader.scala
@@ -39,7 +39,7 @@ trait PBFieldReaderImplicits {
           case tag                        => input.skipField(tag)
         }
       }
-      as.head
+      as.headOption.getOrElse(reader.defaultValue)
     }
 
   implicit def optionalFieldReader[A](

--- a/src/main/scala/pbdirect/PBFormat.scala
+++ b/src/main/scala/pbdirect/PBFormat.scala
@@ -23,6 +23,7 @@ object PBFormat extends PBFormatImplicits {
     new PBFormat[A] {
       override def read(input: CodedInputStream): A = reader.read(input)
       override def wireType: Int                    = writer.wireType
+      override def isDefault(value: A): Boolean     = writer.isDefault(value)
       override def writeWithoutTag(value: A, out: CodedOutputStream): Unit =
         writer.writeWithoutTag(value, out)
     }

--- a/src/main/scala/pbdirect/PBFormat.scala
+++ b/src/main/scala/pbdirect/PBFormat.scala
@@ -24,6 +24,7 @@ object PBFormat extends PBFormatImplicits {
       override def read(input: CodedInputStream): A = reader.read(input)
       override def wireType: Int                    = writer.wireType
       override def isDefault(value: A): Boolean     = writer.isDefault(value)
+      override def defaultValue: A                  = reader.defaultValue
       override def writeWithoutTag(value: A, out: CodedOutputStream): Unit =
         writer.writeWithoutTag(value, out)
     }

--- a/src/main/scala/pbdirect/PBScalarValueReader.scala
+++ b/src/main/scala/pbdirect/PBScalarValueReader.scala
@@ -6,60 +6,78 @@ import shapeless._
 import enumeratum.values.{IntEnum, IntEnumEntry}
 
 trait PBScalarValueReader[A] {
+  def defaultValue: A
   def read(input: CodedInputStream): A
 }
 
 trait PBScalarValueReaderImplicits_1 {
 
-  def instance[A](f: CodedInputStream => A): PBScalarValueReader[A] =
+  def instance[A](default: A)(f: CodedInputStream => A): PBScalarValueReader[A] =
     new PBScalarValueReader[A] {
+      override def defaultValue: A                  = default
       override def read(input: CodedInputStream): A = f(input)
     }
 
   implicit def embeddedMessageReader[A](
-      implicit reader: PBMessageReader[A]): PBScalarValueReader[A] =
-    instance { (input: CodedInputStream) =>
+      implicit reader: PBMessageReader[A]): PBScalarValueReader[A] = {
+
+    // To construct a default instance of the message
+    // we decode a byte array of length zero,
+    // i.e. with all of the message's fields missing
+    val default: A = reader.read(Array[Byte]())
+
+    instance(default) { (input: CodedInputStream) =>
       val bytes = input.readByteArray()
       reader.read(bytes)
     }
+  }
 
 }
 
 trait PBScalarValueReaderImplicits extends PBScalarValueReaderImplicits_1 {
 
   implicit object BooleanReader$ extends PBScalarValueReader[Boolean] {
+    override def defaultValue: Boolean                  = false
     override def read(input: CodedInputStream): Boolean = input.readBool()
   }
   // Stored as variants, but larger in memory: https://groups.google.com/forum/#!topic/protobuf/Er39mNGnRWU
   implicit object ByteReader$ extends PBScalarValueReader[Byte] {
+    override def defaultValue: Byte                  = 0.toByte
     override def read(input: CodedInputStream): Byte = input.readInt32().toByte
   }
   // Stored as variants, but larger in memory: https://groups.google.com/forum/#!topic/protobuf/Er39mNGnRWU
   implicit object ShortReader$ extends PBScalarValueReader[Short] {
+    override def defaultValue: Short                  = 0.toShort
     override def read(input: CodedInputStream): Short = input.readInt32().toShort
   }
   implicit object IntReader$ extends PBScalarValueReader[Int] {
+    override def defaultValue: Int                  = 0
     override def read(input: CodedInputStream): Int = input.readInt32()
   }
   implicit object LongReader$ extends PBScalarValueReader[Long] {
+    override def defaultValue: Long                  = 0L
     override def read(input: CodedInputStream): Long = input.readInt64()
   }
   implicit object FloatReader$ extends PBScalarValueReader[Float] {
+    override def defaultValue: Float                  = 0.0F
     override def read(input: CodedInputStream): Float = input.readFloat()
   }
   implicit object DoubleReader$ extends PBScalarValueReader[Double] {
+    override def defaultValue: Double                  = 0.0
     override def read(input: CodedInputStream): Double = input.readDouble()
   }
   implicit object StringReader$ extends PBScalarValueReader[String] {
+    override def defaultValue: String                  = ""
     override def read(input: CodedInputStream): String = input.readString()
   }
   implicit object BytesReader$ extends PBScalarValueReader[Array[Byte]] {
+    override def defaultValue: Array[Byte]                  = Array()
     override def read(input: CodedInputStream): Array[Byte] = input.readByteArray()
   }
 
   implicit object FunctorReader extends Functor[PBScalarValueReader] {
     override def map[A, B](reader: PBScalarValueReader[A])(f: A => B): PBScalarValueReader[B] =
-      instance { (input: CodedInputStream) =>
+      instance(default = f(reader.defaultValue)) { (input: CodedInputStream) =>
         f(reader.read(input))
       }
   }
@@ -68,31 +86,37 @@ trait PBScalarValueReaderImplicits extends PBScalarValueReaderImplicits_1 {
       implicit
       values: Enum.Values[A],
       ordering: Ordering[A],
-      reader: PBScalarValueReader[Int]): PBScalarValueReader[A] = instance {
-    (input: CodedInputStream) =>
+      reader: PBScalarValueReader[Int]): PBScalarValueReader[A] =
+    instance(default = Enum.fromInt[A](0)) { (input: CodedInputStream) =>
       Enum.fromInt[A](reader.read(input))
-  }
+    }
 
   implicit def enumerationReader[E <: Enumeration](
       implicit
       reader: PBScalarValueReader[Int],
-      gen: Generic.Aux[E, HNil]): PBScalarValueReader[E#Value] = instance {
-    (input: CodedInputStream) =>
-      val enum = gen.from(HNil)
+      gen: Generic.Aux[E, HNil]): PBScalarValueReader[E#Value] = {
+    val enum    = gen.from(HNil)
+    val default = enum(0)
+    instance[E#Value](default) { (input: CodedInputStream) =>
       enum(reader.read(input))
+    }
   }
 
   implicit def enumeratumIntEnumEntryReader[E <: IntEnumEntry](
       implicit
       reader: PBScalarValueReader[Int],
-      enum: IntEnum[E]): PBScalarValueReader[E] = instance { (input: CodedInputStream) =>
-    enum.withValue(reader.read(input))
-  }
+      enum: IntEnum[E]): PBScalarValueReader[E] =
+    instance(default = enum.withValue(0)) { (input: CodedInputStream) =>
+      enum.withValue(reader.read(input))
+    }
 
   implicit def keyValuePairReader[K, V](
       implicit keyReader: PBScalarValueReader[K],
-      valueReader: PBScalarValueReader[V]): PBScalarValueReader[(K, V)] = instance {
-    (input: CodedInputStream) =>
+      valueReader: PBScalarValueReader[V]): PBScalarValueReader[(K, V)] = {
+    val defaultKey   = keyReader.defaultValue
+    val defaultValue = valueReader.defaultValue
+    val default      = (defaultKey, defaultValue)
+    instance(default) { (input: CodedInputStream) =>
       val bytes = input.readByteArray()
       val in    = CodedInputStream.newInstance(bytes)
       in.readTag()
@@ -100,6 +124,7 @@ trait PBScalarValueReaderImplicits extends PBScalarValueReaderImplicits_1 {
       in.readTag()
       val value = valueReader.read(in)
       (key, value)
+    }
   }
 
 }

--- a/src/main/scala/pbdirect/PBScalarValueWriter.scala
+++ b/src/main/scala/pbdirect/PBScalarValueWriter.scala
@@ -23,6 +23,26 @@ trait PBScalarValueWriter[A] {
   def wireType: Int
 
   /**
+   * Whether the given value would be encoded as the default value
+   * for its corresponding protobuf scalar type.
+   *
+   * If the field has the default value, we need to skip it when
+   * writing to protobuf.
+   *
+   * Default values for the protobuf scalar types are as follows:
+   *
+   * string -> ""
+   * bytes -> empty bytes
+   * bool -> false
+   * all numeric types -> zero
+   * enums -> the first defined enum value, which must be 0
+   *
+   * For embedded message fields, there isn't a sensible default value
+   * so this method will always return false.
+   */
+  def isDefault(value: A): Boolean
+
+  /**
    * Write the value to the output stream *without* prefixing a tag.
    */
   def writeWithoutTag(value: A, out: CodedOutputStream): Unit
@@ -30,17 +50,13 @@ trait PBScalarValueWriter[A] {
 }
 
 trait LowPriorityPBScalarValueWriterImplicits {
-  def instance[A](theWireType: Int)(f: (A, CodedOutputStream) => Unit): PBScalarValueWriter[A] =
-    new PBScalarValueWriter[A] {
-      override def wireType: Int = theWireType
-      override def writeWithoutTag(value: A, out: CodedOutputStream): Unit =
-        f(value, out)
-    }
 
   implicit def embeddedMessageWriter[A](
       implicit messageWriter: PBMessageWriter[A]): PBScalarValueWriter[A] =
-    instance(WIRETYPE_LENGTH_DELIMITED) { (message, out) =>
-      {
+    new PBScalarValueWriter[A] {
+      override def wireType: Int                  = WIRETYPE_LENGTH_DELIMITED
+      override def isDefault(message: A): Boolean = false
+      override def writeWithoutTag(message: A, out: CodedOutputStream): Unit = {
         val buffer    = new ByteArrayOutputStream()
         val bufferOut = CodedOutputStream.newInstance(buffer)
         messageWriter.writeTo(message, bufferOut)
@@ -54,85 +70,131 @@ trait LowPriorityPBScalarValueWriterImplicits {
 trait PBScalarValueWriterImplicits extends LowPriorityPBScalarValueWriterImplicits {
 
   implicit val booleanWriter: PBScalarValueWriter[Boolean] =
-    instance(WIRETYPE_VARINT) { (value, out) =>
-      out.writeBoolNoTag(value)
+    new PBScalarValueWriter[Boolean] {
+      override def wireType: Int                      = WIRETYPE_VARINT
+      override def isDefault(value: Boolean): Boolean = !value
+      override def writeWithoutTag(value: Boolean, out: CodedOutputStream): Unit =
+        out.writeBoolNoTag(value)
     }
 
   implicit val byteWriter: PBScalarValueWriter[Byte] =
-    instance(WIRETYPE_VARINT) { (value, out) =>
-      out.writeInt32NoTag(value.toInt)
+    new PBScalarValueWriter[Byte] {
+      override def wireType: Int                   = WIRETYPE_VARINT
+      override def isDefault(value: Byte): Boolean = value == 0.toByte
+      override def writeWithoutTag(value: Byte, out: CodedOutputStream): Unit =
+        out.writeInt32NoTag(value.toInt)
     }
 
   implicit val shortWriter: PBScalarValueWriter[Short] =
-    instance(WIRETYPE_VARINT) { (value, out) =>
-      out.writeInt32NoTag(value.toInt)
+    new PBScalarValueWriter[Short] {
+      override def wireType: Int                    = WIRETYPE_VARINT
+      override def isDefault(value: Short): Boolean = value == 0.toShort
+      override def writeWithoutTag(value: Short, out: CodedOutputStream): Unit =
+        out.writeInt32NoTag(value.toInt)
     }
 
   implicit val intWriter: PBScalarValueWriter[Int] =
-    instance(WIRETYPE_VARINT) { (value, out) =>
-      out.writeInt32NoTag(value)
+    new PBScalarValueWriter[Int] {
+      override def wireType: Int                  = WIRETYPE_VARINT
+      override def isDefault(value: Int): Boolean = value == 0
+      override def writeWithoutTag(value: Int, out: CodedOutputStream): Unit =
+        out.writeInt32NoTag(value)
     }
 
   implicit val longWriter: PBScalarValueWriter[Long] =
-    instance(WIRETYPE_VARINT) { (value, out) =>
-      out.writeInt64NoTag(value)
+    new PBScalarValueWriter[Long] {
+      override def wireType: Int                   = WIRETYPE_VARINT
+      override def isDefault(value: Long): Boolean = value == 0L
+      override def writeWithoutTag(value: Long, out: CodedOutputStream): Unit =
+        out.writeInt64NoTag(value)
     }
 
   implicit val floatWriter: PBScalarValueWriter[Float] =
-    instance(WIRETYPE_FIXED32) { (value, out) =>
-      out.writeFloatNoTag(value)
+    new PBScalarValueWriter[Float] {
+      override def wireType: Int                    = WIRETYPE_FIXED32
+      override def isDefault(value: Float): Boolean = value == 0.0F
+      override def writeWithoutTag(value: Float, out: CodedOutputStream): Unit =
+        out.writeFloatNoTag(value)
     }
 
   implicit val doubleWriter: PBScalarValueWriter[Double] =
-    instance(WIRETYPE_FIXED64) { (value, out) =>
-      out.writeDoubleNoTag(value)
+    new PBScalarValueWriter[Double] {
+      override def wireType: Int                     = WIRETYPE_FIXED64
+      override def isDefault(value: Double): Boolean = value == 0.0
+      override def writeWithoutTag(value: Double, out: CodedOutputStream): Unit =
+        out.writeDoubleNoTag(value)
     }
 
   implicit val stringWriter: PBScalarValueWriter[String] =
-    instance(WIRETYPE_LENGTH_DELIMITED) { (value, out) =>
-      out.writeStringNoTag(value)
+    new PBScalarValueWriter[String] {
+      override def wireType: Int                     = WIRETYPE_LENGTH_DELIMITED
+      override def isDefault(value: String): Boolean = value.isEmpty
+      override def writeWithoutTag(value: String, out: CodedOutputStream): Unit =
+        out.writeStringNoTag(value)
     }
 
   implicit val bytesWriter: PBScalarValueWriter[Array[Byte]] =
-    instance(WIRETYPE_LENGTH_DELIMITED) { (value, out) =>
-      out.writeByteArrayNoTag(value)
+    new PBScalarValueWriter[Array[Byte]] {
+      override def wireType: Int                          = WIRETYPE_LENGTH_DELIMITED
+      override def isDefault(value: Array[Byte]): Boolean = value.isEmpty
+      override def writeWithoutTag(value: Array[Byte], out: CodedOutputStream): Unit =
+        out.writeByteArrayNoTag(value)
     }
 
   implicit def keyValuePairWriter[K, V](
-      implicit keyFieldWriter: PBFieldWriter[K],
-      valueFieldWriter: PBFieldWriter[V]): PBScalarValueWriter[(K, V)] =
-    instance(WIRETYPE_LENGTH_DELIMITED) { (pair, out) =>
-      val buffer    = new ByteArrayOutputStream()
-      val bufferOut = CodedOutputStream.newInstance(buffer)
-      keyFieldWriter.writeTo(1, pair._1, bufferOut)
-      valueFieldWriter.writeTo(2, pair._2, bufferOut)
-      bufferOut.flush()
-      out.writeByteArrayNoTag(buffer.toByteArray)
+      implicit keyWriter: PBScalarValueWriter[K],
+      valueWriter: PBScalarValueWriter[V]): PBScalarValueWriter[(K, V)] =
+    new PBScalarValueWriter[(K, V)] {
+      override def wireType: Int                    = WIRETYPE_LENGTH_DELIMITED
+      override def isDefault(pair: (K, V)): Boolean = false
+      override def writeWithoutTag(pair: (K, V), out: CodedOutputStream): Unit = {
+        val buffer    = new ByteArrayOutputStream()
+        val bufferOut = CodedOutputStream.newInstance(buffer)
+        bufferOut.writeTag(1, keyWriter.wireType)
+        keyWriter.writeWithoutTag(pair._1, bufferOut)
+        bufferOut.writeTag(2, valueWriter.wireType)
+        valueWriter.writeWithoutTag(pair._2, bufferOut)
+        bufferOut.flush()
+        out.writeByteArrayNoTag(buffer.toByteArray)
+      }
     }
 
   implicit def enumWriter[E](
       implicit values: Enum.Values[E],
       ordering: Ordering[E]): PBScalarValueWriter[E] =
-    instance(WIRETYPE_VARINT) { (value, out) =>
-      out.writeInt32NoTag(Enum.toInt(value))
+    new PBScalarValueWriter[E] {
+      override def wireType: Int                = WIRETYPE_VARINT
+      override def isDefault(value: E): Boolean = Enum.toInt(value) == 0
+      override def writeWithoutTag(value: E, out: CodedOutputStream): Unit =
+        out.writeInt32NoTag(Enum.toInt(value))
     }
 
   implicit def enumerationWriter[E <: Enumeration#Value]: PBScalarValueWriter[E] =
-    instance(WIRETYPE_VARINT) { (value, out) =>
-      out.writeInt32NoTag(value.id)
+    new PBScalarValueWriter[E] {
+      override def wireType: Int                = WIRETYPE_VARINT
+      override def isDefault(value: E): Boolean = value.id == 0
+      override def writeWithoutTag(value: E, out: CodedOutputStream): Unit =
+        out.writeInt32NoTag(value.id)
     }
 
   implicit def enumeratumIntEnumEntryWriter[E <: IntEnumEntry]: PBScalarValueWriter[E] =
-    instance(WIRETYPE_VARINT) { (entry, out) =>
-      out.writeInt32NoTag(entry.value)
+    new PBScalarValueWriter[E] {
+      override def wireType: Int                = WIRETYPE_VARINT
+      override def isDefault(entry: E): Boolean = entry.value == 0
+      override def writeWithoutTag(entry: E, out: CodedOutputStream): Unit =
+        out.writeInt32NoTag(entry.value)
     }
 
   implicit object ContravariantWriter extends Contravariant[PBScalarValueWriter] {
     override def contramap[A, B](writer: PBScalarValueWriter[A])(f: B => A) =
-      instance(writer.wireType) { (b: B, out: CodedOutputStream) =>
-        writer.writeWithoutTag(f(b), out)
+      new PBScalarValueWriter[B] {
+        override def wireType: Int            = writer.wireType
+        override def isDefault(b: B): Boolean = writer.isDefault(f(b))
+        override def writeWithoutTag(b: B, out: CodedOutputStream): Unit =
+          writer.writeWithoutTag(f(b), out)
       }
   }
+
 }
 
 object PBScalarValueWriter extends PBScalarValueWriterImplicits {

--- a/src/main/scala/pbdirect/PBScalarValueWriter.scala
+++ b/src/main/scala/pbdirect/PBScalarValueWriter.scala
@@ -145,8 +145,9 @@ trait PBScalarValueWriterImplicits extends LowPriorityPBScalarValueWriterImplici
       implicit keyWriter: PBScalarValueWriter[K],
       valueWriter: PBScalarValueWriter[V]): PBScalarValueWriter[(K, V)] =
     new PBScalarValueWriter[(K, V)] {
-      override def wireType: Int                    = WIRETYPE_LENGTH_DELIMITED
-      override def isDefault(pair: (K, V)): Boolean = false
+      override def wireType: Int = WIRETYPE_LENGTH_DELIMITED
+      override def isDefault(pair: (K, V)): Boolean =
+        keyWriter.isDefault(pair._1) && valueWriter.isDefault(pair._2)
       override def writeWithoutTag(pair: (K, V), out: CodedOutputStream): Unit = {
         val buffer    = new ByteArrayOutputStream()
         val bufferOut = CodedOutputStream.newInstance(buffer)

--- a/src/test/scala/pbdirect/PBFieldReaderSpec.scala
+++ b/src/test/scala/pbdirect/PBFieldReaderSpec.scala
@@ -109,6 +109,54 @@ class PBFieldReaderSpec extends AnyWordSpecLike with Matchers {
       PBFieldReader[List[Metric]]
         .read(1, bytes) shouldBe Metric("metric", "microservices", "node", 12F, 12345) :: Nil
     }
+    "use the default value when reading a missing Boolean from Protobuf" in {
+      PBFieldReader[Boolean].read(1, Array.empty[Byte]) shouldBe false
+    }
+    "use the default value when reading a missing Byte from Protobuf" in {
+      PBFieldReader[Byte].read(1, Array.empty[Byte]) shouldBe 0.toByte
+    }
+    "use the default value when reading a missing Short from Protobuf" in {
+      PBFieldReader[Short].read(1, Array.empty[Byte]) shouldBe 0.toShort
+    }
+    "use the default value when reading a missing Int from Protobuf" in {
+      PBFieldReader[Int].read(1, Array.empty[Byte]) shouldBe 0
+    }
+    "use the default value when reading a missing Long from Protobuf" in {
+      PBFieldReader[Long].read(1, Array.empty[Byte]) shouldBe 0L
+    }
+    "use the default value when reading a missing Float from Protobuf" in {
+      PBFieldReader[Float].read(1, Array.empty[Byte]) shouldBe 0.0F
+    }
+    "use the default value when reading a missing Double from Protobuf" in {
+      PBFieldReader[Double].read(1, Array.empty[Byte]) shouldBe 0.0
+    }
+    "use the default value when reading a missing String from Protobuf" in {
+      PBFieldReader[String].read(1, Array.empty[Byte]) shouldBe ""
+    }
+    "use the default value when reading a missing byte array from Protobuf" in {
+      PBFieldReader[Array[Byte]].read(1, Array.empty[Byte]) shouldBe Array.empty[Byte]
+    }
+    "use the default value when reading a missing enumeration from Protobuf" in {
+      case object Grade extends Enumeration {
+        val GradeA, GradeB = Value
+      }
+      PBFieldReader[Grade.Value].read(1, Array.empty[Byte]) shouldBe Grade.GradeA
+    }
+    "use the default value when reading a missing enum from Protobuf" in {
+      sealed trait Grade extends Pos
+      case object GradeA extends Grade with Pos._0
+      case object GradeB extends Grade with Pos._1
+      PBFieldReader[Grade].read(1, Array.empty[Byte]) shouldBe GradeA
+    }
+    "use the default value when reading a missing enumeratum IntEnumEntry from Protobuf" in {
+      PBFieldReader[Quality].read(1, Array.empty[Byte]) shouldBe Quality.Good
+    }
+    "use the default value when reading a missing embedded message from Protobuf" in {
+      case class FurtherEmbeddedMessage(value: Int)
+      case class EmbeddedMessage(a: Int, b: String, c: FurtherEmbeddedMessage)
+      PBFieldReader[EmbeddedMessage]
+        .read(1, Array.empty[Byte]) shouldBe EmbeddedMessage(0, "", FurtherEmbeddedMessage(0))
+    }
   }
 }
 

--- a/src/test/scala/pbdirect/PBFieldWriterSpec.scala
+++ b/src/test/scala/pbdirect/PBFieldWriterSpec.scala
@@ -47,13 +47,14 @@ class PBFieldWriterSpec extends AnyWordSpecLike with Matchers {
       object Grade extends Enumeration {
         val GradeA, GradeB = Value
       }
+      write(Grade.GradeA) shouldBe Array[Byte]() // skip field because default value
       write(Grade.GradeB) shouldBe Array[Byte](8, 1)
     }
     "write an enum to Protobuf" in {
       sealed trait Grade extends Pos
       case object GradeA extends Grade with Pos._0
       case object GradeB extends Grade with Pos._1
-      write(GradeA: Grade) shouldBe Array[Byte](8, 0)
+      write(GradeA: Grade) shouldBe Array[Byte]() // skip field because default value
       write(GradeB: Grade) shouldBe Array[Byte](8, 1)
     }
     "write an enumeratum IntEnumEntry to Protobuf" in {
@@ -66,6 +67,7 @@ class PBFieldWriterSpec extends AnyWordSpecLike with Matchers {
 
         val values = findValues
       }
+      write(Quality.Good: Quality) shouldBe Array[Byte]() // skip field because default value
       write(Quality.OK: Quality) shouldBe Array[Byte](8, 3)
     }
     "write an Option[Int] to Protobuf" in {
@@ -110,6 +112,26 @@ class PBFieldWriterSpec extends AnyWordSpecLike with Matchers {
       write(Metric("metric", "microservices", "node", 12F, 12345) :: Nil) shouldBe Array[Byte](10,
         37, 10, 6, 109, 101, 116, 114, 105, 99, 18, 13, 109, 105, 99, 114, 111, 115, 101, 114, 118,
         105, 99, 101, 115, 26, 4, 110, 111, 100, 101, 37, 0, 0, 64, 65, 40, -71, 96)
+    }
+    "skip a Boolean field with the default value" in {
+      write(false) shouldBe Array[Byte]()
+    }
+    "skip an Int field with the default value" in {
+      write(0) shouldBe Array[Byte]()
+    }
+    "skip a String field with the default value" in {
+      write("") shouldBe Array[Byte]()
+    }
+    "skip an empty repeated field" in {
+      write(List[Int]()) shouldBe Array[Byte]()
+    }
+    "not skip default values in a repeated field" in {
+      write(List[Int](1, 0, 2)) shouldBe Array[Byte](8, 1, 8, 0, 8, 2)
+    }
+    "not skip default keys or values in a map field" in {
+      write(Map[Int, String](0 -> "zero", 1 -> "one", 2 -> "")) shouldBe
+        Array(10, 8, 8, 0, 18, 4, 122, 101, 114, 111, 10, 7, 8, 1, 18, 3, 111, 110, 101, 10, 4, 8,
+          2, 18, 0)
     }
   }
 }

--- a/src/test/scala/pbdirect/RoundTripSpec.scala
+++ b/src/test/scala/pbdirect/RoundTripSpec.scala
@@ -9,6 +9,13 @@ import enumeratum.values.IntEnum
 import shapeless._
 import shapeless.ops.hlist._
 
+sealed abstract class Status(val value: Int) extends IntEnumEntry
+object Status extends IntEnum[Status] {
+  case object Running extends Status(0)
+  case object Stopped extends Status(5)
+  val values = findValues
+}
+
 class RoundTripSpec extends AnyFlatSpec with Checkers {
   import RoundTripSpec._
 
@@ -36,13 +43,6 @@ class RoundTripSpec extends AnyFlatSpec with Checkers {
 }
 
 object RoundTripSpec {
-
-  sealed abstract class Status(val value: Int) extends IntEnumEntry
-  object Status extends IntEnum[Status] {
-    case object Running extends Status(0)
-    case object Stopped extends Status(5)
-    val values = findValues
-  }
 
   case class EmptyMessage()
 
@@ -152,8 +152,8 @@ trait PBEquivalenceImplicits_1 extends PBEquivalenceImplicits_2 {
   implicit val stringOption: PBEquivalence[Option[String]] = option("stringOption", "")
   implicit val bytesOption: PBEquivalence[Option[Array[Byte]]] =
     option("bytesOption", Array.empty[Byte])
-  implicit val enumOption: PBEquivalence[Option[RoundTripSpec.Status]] =
-    option("enumOption", RoundTripSpec.Status.withValue(0))
+  implicit val enumOption: PBEquivalence[Option[Status]] =
+    option("enumOption", Status.withValue(0))
 
   object fieldEquivalence extends Poly2 {
     implicit def defaultCase[A](implicit equiv: PBEquivalence[A]): Case.Aux[A, A, Boolean] =

--- a/src/test/scala/pbdirect/RoundTripSpec.scala
+++ b/src/test/scala/pbdirect/RoundTripSpec.scala
@@ -20,7 +20,10 @@ class RoundTripSpec extends AnyFlatSpec with Checkers {
     PropertyCheckConfiguration(minSuccessful = 500)
 
   "round trip to protobuf and back" should "be an identity" in check {
-    pending // because handling of missing values when reading is not implemented yet
+    // TODO the test is failing because e.g. Some(false) gets turned into None.
+    // Need to decide what the correct behaviour is and adjust either the test
+    // or the implementation.
+    pending
 
     forAllNoShrink { (message: MessageThree) =>
       val roundtripped = message.toPB.pbTo[MessageThree]

--- a/src/test/scala/pbdirect/RoundTripSpec.scala
+++ b/src/test/scala/pbdirect/RoundTripSpec.scala
@@ -6,34 +6,42 @@ import org.scalacheck.ScalacheckShapeless._
 import org.scalacheck.Prop._
 import enumeratum.values.IntEnumEntry
 import enumeratum.values.IntEnum
-
-sealed abstract class Status(val value: Int) extends IntEnumEntry
-object Status extends IntEnum[Status] {
-  case object Running extends Status(0)
-  case object Stopped extends Status(5)
-  val values = findValues
-}
+import shapeless._
+import shapeless.ops.hlist._
 
 class RoundTripSpec extends AnyFlatSpec with Checkers {
+  import RoundTripSpec._
 
   implicit override val generatorDrivenConfig =
     PropertyCheckConfiguration(minSuccessful = 500)
 
-  "round trip to protobuf and back" should "be an identity" in check {
-    // TODO the test is failing because e.g. Some(false) gets turned into None.
-    // Need to decide what the correct behaviour is and adjust either the test
-    // or the implementation.
-    pending
+  implicit class PBEquivalenceSyntax[A](val a: A)(implicit equivalence: PBEquivalence[A]) {
+    def equiv(a2: A): Boolean = equivalence.equiv(a, a2)
+  }
 
+  "round trip to protobuf and back" should "result in a message equivalent to the original" in check {
     forAllNoShrink { (message: MessageThree) =>
       val roundtripped = message.toPB.pbTo[MessageThree]
 
-      // arrays use reference equality :(
-      s"message after roundtrip = $roundtripped" |: all(
-        "byte array" |: roundtripped.bytes.toList === message.bytes.toList,
-        "rest of message" |: roundtripped.copy(bytes = message.bytes) === message
-      )
+      val label = s"""|
+        |message before roundtrip = $message
+        |
+        |message after  roundtrip = $roundtripped
+        |""".stripMargin
+
+      label |: (message equiv roundtripped)
     }
+  }
+
+}
+
+object RoundTripSpec {
+
+  sealed abstract class Status(val value: Int) extends IntEnumEntry
+  object Status extends IntEnum[Status] {
+    case object Running extends Status(0)
+    case object Stopped extends Status(5)
+    val values = findValues
   }
 
   case class EmptyMessage()
@@ -70,8 +78,114 @@ class RoundTripSpec extends AnyFlatSpec with Checkers {
       @pbIndex(32) intStringMap: Map[Int, String],
       @pbIndex(34) stringBoolListMap: Map[String, List[Boolean]],
       @pbIndex(36) nestedMessage: MessageTwo,
-      @pbIndex(38) repeatedNestedMessage: List[MessageTwo],
-      @pbIndex(40) intMessageMap: Map[Int, MessageTwo]
+      @pbIndex(38) optionalNestedMessage: Option[MessageTwo],
+      @pbIndex(40) repeatedNestedMessage: List[MessageTwo],
+      @pbIndex(42) intMessageMap: Map[Int, MessageTwo]
   )
 
+}
+
+/**
+ * We define a commutative equivalence relation for protobuf-encoded data
+ * with the following laws:
+ *
+ * - ∀ x. x == x => x equiv x
+ *   (all data is equivalent to itself)
+ *
+ * - ∀ scalar types T. Some(d: T) equiv None iff d is the protobuf default value for type T
+ *   (because the data is not written on the wire, it's reasonable to decode it as None)
+ *
+ * - ∀ scalar types T. None equiv Some(d: T) iff d is the protobuf default value for type T
+ *   (because it's also reasonable to decode a missing Option as Some(defaultValue)
+ *
+ * - ∀ messages m1(x1, x2, ..., xN), m2(y1, y2, ..., yN).
+ *     (∀ 1 ≦ n ≦ N. xn equiv yn) => m1 equiv m2
+ *   (two messages are equivalent if all their fields are equivalent)
+ *
+ */
+trait PBEquivalence[A] {
+  def equiv(a1: A, a2: A): Boolean
+  def show: String
+  override def toString(): String = show
+}
+
+trait PBEquivalenceImplicits_2 {
+
+  def instance[A](description: String)(f: (A, A) => Boolean): PBEquivalence[A] =
+    new PBEquivalence[A] {
+      override def equiv(a1: A, a2: A): Boolean = f(a1, a2)
+      override def show: String                 = description
+    }
+
+  implicit def refl[A]: PBEquivalence[A] = instance("refl") { (a1, a2) =>
+    a1 == a2
+  }
+
+}
+
+trait PBEquivalenceImplicits_1 extends PBEquivalenceImplicits_2 {
+
+  // special treatment for arrays because == doesn't work (it uses reference equality)
+  implicit def array[A](implicit listEquiv: PBEquivalence[List[A]]): PBEquivalence[Array[A]] =
+    instance("array") { (a1, a2) =>
+      listEquiv.equiv(a1.toList, a2.toList)
+    }
+
+  def option[A](description: String, defaultValue: A)(
+      implicit equiv: PBEquivalence[A]): PBEquivalence[Option[A]] =
+    instance(description) {
+      case (Some(x), None) if equiv.equiv(x, defaultValue) => true
+      case (Some(_), None)                                 => false
+      case (None, Some(x)) if equiv.equiv(x, defaultValue) => true
+      case (None, Some(_))                                 => false
+      case (None, None)                                    => true
+      case (Some(x), Some(y))                              => equiv.equiv(x, y)
+    }
+
+  implicit val byteOption: PBEquivalence[Option[Byte]]     = option("byteOption", 0.toByte)
+  implicit val shortOption: PBEquivalence[Option[Short]]   = option("shortOption", 0.toShort)
+  implicit val intOption: PBEquivalence[Option[Int]]       = option("intOption", 0)
+  implicit val longOption: PBEquivalence[Option[Long]]     = option("longOption", 0L)
+  implicit val floatOption: PBEquivalence[Option[Float]]   = option("floatOption", 0.0F)
+  implicit val doubleOption: PBEquivalence[Option[Double]] = option("doubleOption", 0.0)
+  implicit val boolOption: PBEquivalence[Option[Boolean]]  = option("boolOption", false)
+  implicit val stringOption: PBEquivalence[Option[String]] = option("stringOption", "")
+  implicit val bytesOption: PBEquivalence[Option[Array[Byte]]] =
+    option("bytesOption", Array.empty[Byte])
+  implicit val enumOption: PBEquivalence[Option[RoundTripSpec.Status]] =
+    option("enumOption", RoundTripSpec.Status.withValue(0))
+
+  object fieldEquivalence extends Poly2 {
+    implicit def defaultCase[A](implicit equiv: PBEquivalence[A]): Case.Aux[A, A, Boolean] =
+      at[A, A](equiv.equiv(_, _))
+  }
+
+  object conj extends Poly2 {
+    implicit val defaultCase: Case.Aux[Boolean, Boolean, Boolean] =
+      at[Boolean, Boolean](_ && _)
+  }
+
+  implicit val hnil: PBEquivalence[HNil] = instance("hnil")((_, _) => true)
+
+  // two messages of type A are equivalent if all their fields are equivalent
+  implicit def message[A, R <: HList, FEs <: HList](
+      implicit
+      gen: Generic.Aux[A, R],
+      fieldEquivs: ZipWith.Aux[R, R, fieldEquivalence.type, FEs],
+      fold: LeftFolder.Aux[FEs, Boolean, conj.type, Boolean]): PBEquivalence[A] =
+    instance("message") {
+      case (a1, a2) =>
+        val hlist1   = gen.to(a1)
+        val hlist2   = gen.to(a2)
+        val booleans = hlist1.zipWith(hlist2)(fieldEquivalence) // fieldEquivs.apply(hlist1, hlist2)
+        val result   = booleans.foldLeft(true)(conj)
+        if (!result)
+          println(booleans)
+        result
+    }
+
+}
+
+object PBEquivalence extends PBEquivalenceImplicits_1 {
+  def apply[A: PBEquivalence]: PBEquivalence[A] = implicitly
 }

--- a/src/test/scala/pbdirect/RoundTripSpec.scala
+++ b/src/test/scala/pbdirect/RoundTripSpec.scala
@@ -20,6 +20,8 @@ class RoundTripSpec extends AnyFlatSpec with Checkers {
     PropertyCheckConfiguration(minSuccessful = 500)
 
   "round trip to protobuf and back" should "be an identity" in check {
+    pending // because handling of missing values when reading is not implemented yet
+
     forAllNoShrink { (message: MessageThree) =>
       val roundtripped = message.toPB.pbTo[MessageThree]
 


### PR DESCRIPTION
Fix for https://github.com/higherkindness/mu-scala/issues/606

* When writing a message to the wire, skip the field if it has the default value (0 for numbers, "" for string, etc.)
    * But don't skip writing of list elements even if they have the default value
* When reading from the wire, set any missing fields to their default values
* Add unit tests and update the round-trip test to reflect the new behaviour