### PR TITLE
Support oneof fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ implicit val instantFormat: PBFormat[Instant] =
   PBFormat[Long].imap(Instant.ofEpochMilli)(_.toEpochMilli)
 ```
 
-If you only need a reader you can map over an existing `PBReader`
+If you only need a reader you can map over an existing `PBScalarValueReader`
 
 ```scala
 import java.time.Instant

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The following table gives some examples of how pbdirect decodes missing fields:
 | Scala type | Value given to missing field |
 | --- | --- |
 | `Int`/`Short`/`Byte`/`Long` | `0` |
-| `Double`/Float` | `0.0` |
+| `Double`/`Float` | `0.0` |
 | `String` | `""` |
 | `Array[Byte]` | empty array |
 | `List[_]` | empty list |

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ is equivalent to the following protobuf definition:
 
 ```protobuf
 message MyMessage {
-   optional int32  id      = 1;
-   optional string text    = 3;
-   repeated int32  numbers = 5;
+  int32  id              = 1;
+  string text            = 3;
+  repeated int32 numbers = 5;
 }
 ```
 
@@ -81,9 +81,9 @@ is equivalent to the following protobuf definition:
 
 ```protobuf
 message MyMessage {
-   optional int32  id      = 1;
-   optional string text    = 2;
-   repeated int32  numbers = 3;
+  int32  id              = 1;
+  string text            = 2;
+  repeated int32 numbers = 3;
 }
 ```
 
@@ -131,8 +131,8 @@ If you only need a reader you can map over an existing `PBReader`
 import java.time.Instant
 import cats.syntax.functor._
 
-implicit val instantReader: PBReader[Instant] =
-  PBReader[Long].map(Instant.ofEpochMilli)
+implicit val instantReader: PBScalarValueReader[Instant] =
+  PBScalarValueReader[Long].map(Instant.ofEpochMilli)
 ```
 
 And for a writer you simply contramap over it:
@@ -141,10 +141,73 @@ And for a writer you simply contramap over it:
 import java.time.Instant
 import cats.syntax.contravariant._
 
-implicit val instantWriter: PBFieldWriter[Instant] =
-  PBFieldWriter[Long].contramap(_.toEpochMilli)
+implicit val instantWriter: PBScalarValueWriter[Instant] =
+  PBScalarValueWriter[Long].contramap(_.toEpochMilli)
   )
 ```
+
+## Oneof fields
+
+pbdirect supports protobuf [`oneof` fields](https://developers.google.com/protocol-buffers/docs/proto3#oneof) encoded as [Shapeless](https://github.com/milessabin/shapeless) Coproducts.
+
+For example:
+
+```scala
+case class MyMessage(
+  @pbIndex(1) number: Int,
+  @pbIndex(2,3,4) coproduct: Option[Int :+: String :+: Boolean :+: CNil]
+)
+```
+
+is equivalent to the following protobuf definition:
+
+```protobuf
+message MyMessage {
+  int32 number = 1;
+  oneof coproduct {
+    int32 a  = 2;
+    string b = 3;
+    bool c   = 4;
+  }
+}
+```
+
+There are a couple of restrictions:
+
+* `oneof` fields must have a `@pbIndex` annotation containing the indices of each of the sub-fields
+* The type of `oneof` fields must be a Coproduct wrapped in `Option[_]`. This is so that pbdirect can set the value to `None` when the field is missing when reading a message from protobuf.
+
+## Default values and missing fields
+
+When reading a protobuf message, pbdirect needs to handle missing fields by falling back to some default value. How it does this depends on the type of field.
+
+The following table gives some examples of how pbdirect decodes missing fields:
+
+| Scala type | Value given to missing field |
+| --- | --- |
+| `Int`/`Short`/`Byte`/`Long` | `0` |
+| `Double`/Float` | `0.0` |
+| `String` | `""` |
+| `Array[Byte]` | empty array |
+| `List[_]` | empty list |
+| `Map[_, _]` | empty map |
+| Scala `Enumeration` or [enumeratum](https://github.com/lloydmeta/enumeratum) `IntEnum` | the entry with value 0 |
+| `Option[_]` | `None` |
+| `MyMessage` | an instance of `MyMessage` with all its fields set to their default values |
+| `Int :+: String :+: CNil` | (not supported) |
+| `Option[Int :+: String :+: CNil]` | `None` |
+
+If you have defined your own `PBScalarValueReader` by mapping over one of the
+built-in readers, you will get whatever value is produced by the default value
+of the underlying type.
+
+For example, if your message looks like:
+
+```scala
+case class MyMessage(instant: Instant)
+```
+
+and you use the `instantReader` defined earlier, reading a message with the `instant` field missing would result in `1970-01-01T00:00:00Z`.
 
 [comment]: # (Start Copyright)
 # Copyright

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -94,6 +94,7 @@ object ProjectPlugin extends AutoPlugin {
         ScalafmtFileType,
         TravisFileType(crossScalaVersions.value, orgScriptCICommandKey, orgAfterCISuccessCommandKey)
         // format: ON
-      )
+      ),
+      Compile / console / scalacOptions -= "-Xlint"
     )
 }

--- a/src/main/scala/pbdirect/PBFieldWriter.scala
+++ b/src/main/scala/pbdirect/PBFieldWriter.scala
@@ -3,32 +3,42 @@ package pbdirect
 import com.google.protobuf.CodedOutputStream
 
 trait PBFieldWriter[A] {
-  def writeTo(index: Int, value: A, out: CodedOutputStream): Unit
+
+  /**
+   * @param skipDefaultValue If true, the field should not be written if it is a scalar field with the default value for its type
+   */
+  def writeTo(index: Int, value: A, out: CodedOutputStream, skipDefaultValue: Boolean): Unit
 }
 
 trait PBFieldWriterImplicits {
 
-  def instance[A](f: (Int, A, CodedOutputStream) => Unit): PBFieldWriter[A] =
+  def instance[A](f: (Int, A, CodedOutputStream, Boolean) => Unit): PBFieldWriter[A] =
     new PBFieldWriter[A] {
-      override def writeTo(index: Int, value: A, out: CodedOutputStream): Unit =
-        f(index, value, out)
+      override def writeTo(
+          index: Int,
+          value: A,
+          out: CodedOutputStream,
+          skipDefaultValue: Boolean): Unit =
+        f(index, value, out, skipDefaultValue)
     }
 
   implicit def scalarWriter[A](implicit writer: PBScalarValueWriter[A]): PBFieldWriter[A] =
-    instance { (index: Int, value: A, out: CodedOutputStream) =>
-      if (!writer.isDefault(value)) {
+    instance { (index: Int, value: A, out: CodedOutputStream, skipDefaultValue: Boolean) =>
+      if (skipDefaultValue && writer.isDefault(value)) {
+        // skip the field
+      } else {
         out.writeTag(index, writer.wireType)
         writer.writeWithoutTag(value, out)
       }
     }
 
   implicit def optionWriter[A](implicit writer: PBFieldWriter[A]): PBFieldWriter[Option[A]] =
-    instance { (index: Int, option: Option[A], out: CodedOutputStream) =>
-      option.foreach(v => writer.writeTo(index, v, out))
+    instance { (index: Int, option: Option[A], out: CodedOutputStream, skipDefaultValue: Boolean) =>
+      option.foreach(v => writer.writeTo(index, v, out, skipDefaultValue))
     }
 
   implicit def listWriter[A](implicit writer: PBScalarValueWriter[A]): PBFieldWriter[List[A]] =
-    instance { (index: Int, list: List[A], out: CodedOutputStream) =>
+    instance { (index: Int, list: List[A], out: CodedOutputStream, skipDefaultValue: Boolean) =>
       // TODO when we support writing packed repeated fields,
       // we need to check if the list is empty and skip the field completely
       list.foreach { value =>
@@ -39,19 +49,24 @@ trait PBFieldWriterImplicits {
 
   implicit def mapWriter[K, V](
       implicit writer: PBFieldWriter[List[(K, V)]]): PBFieldWriter[Map[K, V]] =
-    instance { (index: Int, value: Map[K, V], out: CodedOutputStream) =>
-      writer.writeTo(index, value.toList, out)
+    instance { (index: Int, value: Map[K, V], out: CodedOutputStream, skipDefaultValue: Boolean) =>
+      writer.writeTo(index, value.toList, out, skipDefaultValue)
     }
 
   implicit def collectionMapWriter[K, V](
       implicit writer: PBFieldWriter[List[(K, V)]]): PBFieldWriter[collection.Map[K, V]] =
-    instance { (index: Int, value: collection.Map[K, V], out: CodedOutputStream) =>
-      writer.writeTo(index, value.toList, out)
+    instance {
+      (
+          index: Int,
+          value: collection.Map[K, V],
+          out: CodedOutputStream,
+          skipDefaultValue: Boolean) =>
+        writer.writeTo(index, value.toList, out, skipDefaultValue)
     }
 
   implicit def seqWriter[A](implicit writer: PBFieldWriter[List[A]]): PBFieldWriter[Seq[A]] =
-    instance { (index: Int, value: Seq[A], out: CodedOutputStream) =>
-      writer.writeTo(index, value.toList, out)
+    instance { (index: Int, value: Seq[A], out: CodedOutputStream, skipDefaultValue: Boolean) =>
+      writer.writeTo(index, value.toList, out, skipDefaultValue)
     }
 
 }

--- a/src/main/scala/pbdirect/PBMessageReader.scala
+++ b/src/main/scala/pbdirect/PBMessageReader.scala
@@ -4,8 +4,6 @@ import shapeless._
 import shapeless.ops.hlist._
 import shapeless.ops.nat._
 
-import scala.util.Try
-
 trait PBMessageReader[A] {
   def read(bytes: Array[Byte]): A
 }
@@ -37,27 +35,27 @@ trait PBMessageReaderImplicits {
     gen.from(reader.value.read(fieldIndices, bytes))
   }
 
-  implicit val cnilReader: PBMessageReader[CNil] = instance { (bytes: Array[Byte]) =>
-    throw new UnsupportedOperationException("Can't read CNil")
-  }
+  //implicit val cnilReader: PBMessageReader[CNil] = instance { (bytes: Array[Byte]) =>
+  //throw new UnsupportedOperationException("Can't read CNil")
+  //}
 
-  implicit def cconsReader[H, T <: Coproduct](
-      implicit
-      head: PBMessageReader[H],
-      tail: Lazy[PBMessageReader[T]]): PBMessageReader[H :+: T] = instance { (bytes: Array[Byte]) =>
-    Try {
-      Inl(head.read(bytes))
-    } getOrElse {
-      Inr(tail.value.read(bytes))
-    }
-  }
+  //implicit def cconsReader[H, T <: Coproduct](
+  //implicit
+  //head: PBMessageReader[H],
+  //tail: Lazy[PBMessageReader[T]]): PBMessageReader[H :+: T] = instance { (bytes: Array[Byte]) =>
+  //Try {
+  //Inl(head.read(bytes))
+  //} getOrElse {
+  //Inr(tail.value.read(bytes))
+  //}
+  //}
 
-  implicit def coprodReader[A, R <: Coproduct](
-      implicit
-      gen: Generic.Aux[A, R],
-      repr: Lazy[PBMessageReader[R]]): PBMessageReader[A] = instance { (bytes: Array[Byte]) =>
-    gen.from(repr.value.read(bytes))
-  }
+  //implicit def coprodReader[A, R <: Coproduct](
+  //implicit
+  //gen: Generic.Aux[A, R],
+  //repr: Lazy[PBMessageReader[R]]): PBMessageReader[A] = instance { (bytes: Array[Byte]) =>
+  //gen.from(repr.value.read(bytes))
+  //}
 
 }
 

--- a/src/main/scala/pbdirect/PBMessageReader.scala
+++ b/src/main/scala/pbdirect/PBMessageReader.scala
@@ -35,28 +35,6 @@ trait PBMessageReaderImplicits {
     gen.from(reader.value.read(fieldIndices, bytes))
   }
 
-  //implicit val cnilReader: PBMessageReader[CNil] = instance { (bytes: Array[Byte]) =>
-  //throw new UnsupportedOperationException("Can't read CNil")
-  //}
-
-  //implicit def cconsReader[H, T <: Coproduct](
-  //implicit
-  //head: PBMessageReader[H],
-  //tail: Lazy[PBMessageReader[T]]): PBMessageReader[H :+: T] = instance { (bytes: Array[Byte]) =>
-  //Try {
-  //Inl(head.read(bytes))
-  //} getOrElse {
-  //Inr(tail.value.read(bytes))
-  //}
-  //}
-
-  //implicit def coprodReader[A, R <: Coproduct](
-  //implicit
-  //gen: Generic.Aux[A, R],
-  //repr: Lazy[PBMessageReader[R]]): PBMessageReader[A] = instance { (bytes: Array[Byte]) =>
-  //gen.from(repr.value.read(bytes))
-  //}
-
 }
 
 object PBMessageReader extends PBMessageReaderImplicits {

--- a/src/main/scala/pbdirect/PBMessageWriter.scala
+++ b/src/main/scala/pbdirect/PBMessageWriter.scala
@@ -41,25 +41,6 @@ trait PBMessageWriterImplicits {
       writer.value.writeTo(indexedFields, out)
     }
 
-  implicit val cnilWriter: PBMessageWriter[CNil] = instance { (_: CNil, _: CodedOutputStream) =>
-    throw new Exception("Can't write CNil")
-  }
-  implicit def cconsWriter[H, T <: Coproduct](
-      implicit head: PBMessageWriter[H],
-      tail: PBMessageWriter[T]): PBMessageWriter[H :+: T] =
-    instance { (value: H :+: T, out: CodedOutputStream) =>
-      value match {
-        case Inl(h) => head.writeTo(h, out)
-        case Inr(t) => tail.writeTo(t, out)
-      }
-    }
-  implicit def coprodWriter[A, R <: Coproduct](
-      implicit gen: Generic.Aux[A, R],
-      writer: PBMessageWriter[R]): PBMessageWriter[A] =
-    instance { (value: A, out: CodedOutputStream) =>
-      writer.writeTo(gen.to(value), out)
-    }
-
 }
 
 object PBMessageWriter extends PBMessageWriterImplicits {

--- a/src/main/scala/pbdirect/PBOneofFieldReader.scala
+++ b/src/main/scala/pbdirect/PBOneofFieldReader.scala
@@ -1,0 +1,33 @@
+package pbdirect
+
+import shapeless._
+
+trait PBOneofFieldReader[A <: Coproduct] {
+  def read(indices: List[Int], bytes: Array[Byte]): A
+}
+
+trait PBOneofFieldReaderImplicits {
+  def instance[A <: Coproduct](f: (List[Int], Array[Byte]) => A): PBOneofFieldReader[A] =
+    new PBOneofFieldReader[A] {
+      override def read(indices: List[Int], bytes: Array[Byte]): A = f(indices, bytes)
+    }
+
+  implicit val cnilReader: PBOneofFieldReader[CNil] = instance(
+    (_, _) => throw new IllegalStateException("Cannot read CNil"))
+
+  implicit def cconsReader[H, T <: Coproduct](
+      implicit
+      headReader: PBFieldReader[Option[H]],
+      tailReader: Lazy[PBOneofFieldReader[T]]): PBOneofFieldReader[H :+: T] =
+    instance { (indices: List[Int], bytes: Array[Byte]) =>
+      headReader
+        .read(indices.head, bytes)
+        .map(Inl(_))
+        .getOrElse(Inr(tailReader.value.read(indices.tail, bytes)))
+    }
+
+}
+
+object PBOneofFieldReader extends PBOneofFieldReaderImplicits {
+  def apply[A <: Coproduct: PBOneofFieldReader]: PBOneofFieldReader[A] = implicitly
+}

--- a/src/main/scala/pbdirect/PBOneofFieldReader.scala
+++ b/src/main/scala/pbdirect/PBOneofFieldReader.scala
@@ -3,17 +3,16 @@ package pbdirect
 import shapeless._
 
 trait PBOneofFieldReader[A <: Coproduct] {
-  def read(indices: List[Int], bytes: Array[Byte]): A
+  def read(indices: List[Int], bytes: Array[Byte]): Option[A]
 }
 
 trait PBOneofFieldReaderImplicits {
-  def instance[A <: Coproduct](f: (List[Int], Array[Byte]) => A): PBOneofFieldReader[A] =
+  def instance[A <: Coproduct](f: (List[Int], Array[Byte]) => Option[A]): PBOneofFieldReader[A] =
     new PBOneofFieldReader[A] {
-      override def read(indices: List[Int], bytes: Array[Byte]): A = f(indices, bytes)
+      override def read(indices: List[Int], bytes: Array[Byte]): Option[A] = f(indices, bytes)
     }
 
-  implicit val cnilReader: PBOneofFieldReader[CNil] = instance(
-    (_, _) => throw new IllegalStateException("Cannot read CNil"))
+  implicit val cnilReader: PBOneofFieldReader[CNil] = instance((_, _) => None)
 
   implicit def cconsReader[H, T <: Coproduct](
       implicit
@@ -23,7 +22,7 @@ trait PBOneofFieldReaderImplicits {
       headReader
         .read(indices.head, bytes)
         .map(Inl(_))
-        .getOrElse(Inr(tailReader.value.read(indices.tail, bytes)))
+        .orElse(tailReader.value.read(indices.tail, bytes).map(Inr(_)))
     }
 
 }

--- a/src/main/scala/pbdirect/PBOneofFieldWriter.scala
+++ b/src/main/scala/pbdirect/PBOneofFieldWriter.scala
@@ -25,7 +25,7 @@ trait PBOneofFieldWriterImplicits {
       tailWriter: Lazy[PBOneofFieldWriter[T]]): PBOneofFieldWriter[H :+: T] =
     instance { (indices: List[Int], value: H :+: T, out: CodedOutputStream) =>
       value match {
-        case Inl(h) => headWriter.writeTo(indices.head, h, out)
+        case Inl(h) => headWriter.writeTo(indices.head, h, out, skipDefaultValue = false)
         case Inr(t) => tailWriter.value.writeTo(indices.tail, t, out)
       }
     }

--- a/src/main/scala/pbdirect/PBOneofFieldWriter.scala
+++ b/src/main/scala/pbdirect/PBOneofFieldWriter.scala
@@ -1,0 +1,37 @@
+package pbdirect
+
+import com.google.protobuf.CodedOutputStream
+import shapeless._
+
+trait PBOneofFieldWriter[A <: Coproduct] {
+  def writeTo(indices: List[Int], value: A, out: CodedOutputStream): Unit
+}
+
+trait PBOneofFieldWriterImplicits {
+
+  def instance[A <: Coproduct](
+      f: (List[Int], A, CodedOutputStream) => Unit): PBOneofFieldWriter[A] =
+    new PBOneofFieldWriter[A] {
+      override def writeTo(indices: List[Int], value: A, out: CodedOutputStream): Unit =
+        f(indices, value, out)
+    }
+
+  implicit val cnilWriter: PBOneofFieldWriter[CNil] = instance(
+    (_, _, _) => throw new IllegalStateException("Cannot write CNil"))
+
+  implicit def cconsWriter[H, T <: Coproduct](
+      implicit
+      headWriter: PBFieldWriter[H],
+      tailWriter: Lazy[PBOneofFieldWriter[T]]): PBOneofFieldWriter[H :+: T] =
+    instance { (indices: List[Int], value: H :+: T, out: CodedOutputStream) =>
+      value match {
+        case Inl(h) => headWriter.writeTo(indices.head, h, out)
+        case Inr(t) => tailWriter.value.writeTo(indices.tail, t, out)
+      }
+    }
+
+}
+
+object PBOneofFieldWriter extends PBOneofFieldWriterImplicits {
+  def apply[A <: Coproduct: PBOneofFieldWriter]: PBOneofFieldWriter[A] = implicitly
+}

--- a/src/main/scala/pbdirect/PBProductReader.scala
+++ b/src/main/scala/pbdirect/PBProductReader.scala
@@ -29,7 +29,7 @@ trait PBProductReaderImplicits {
   implicit def consOneofProductReader[H <: Coproduct, T <: HList, IT <: HList](
       implicit
       head: PBOneofFieldReader[H],
-      tail: Lazy[PBProductReader[T, IT]]): PBProductReader[H :: T, FieldIndex :: IT] =
+      tail: Lazy[PBProductReader[T, IT]]): PBProductReader[Option[H] :: T, FieldIndex :: IT] =
     PBProductReader.instance { (indices: FieldIndex :: IT, bytes: Array[Byte]) =>
       head.read(indices.head.values, bytes) :: tail.value.read(indices.tail, bytes)
     }

--- a/src/main/scala/pbdirect/PBProductReader.scala
+++ b/src/main/scala/pbdirect/PBProductReader.scala
@@ -20,10 +20,18 @@ trait PBProductReaderImplicits {
 
   implicit def consProductReader[H, T <: HList, IT <: HList](
       implicit
-      headFieldReader: PBFieldReader[H],
+      head: PBFieldReader[H],
       tail: Lazy[PBProductReader[T, IT]]): PBProductReader[H :: T, FieldIndex :: IT] =
     PBProductReader.instance { (indices: FieldIndex :: IT, bytes: Array[Byte]) =>
-      headFieldReader.read(indices.head.values.head, bytes) :: tail.value.read(indices.tail, bytes)
+      head.read(indices.head.values.head, bytes) :: tail.value.read(indices.tail, bytes)
+    }
+
+  implicit def consOneofProductReader[H <: Coproduct, T <: HList, IT <: HList](
+      implicit
+      head: PBOneofFieldReader[H],
+      tail: Lazy[PBProductReader[T, IT]]): PBProductReader[H :: T, FieldIndex :: IT] =
+    PBProductReader.instance { (indices: FieldIndex :: IT, bytes: Array[Byte]) =>
+      head.read(indices.head.values, bytes) :: tail.value.read(indices.tail, bytes)
     }
 
 }

--- a/src/main/scala/pbdirect/PBProductWriter.scala
+++ b/src/main/scala/pbdirect/PBProductWriter.scala
@@ -24,7 +24,7 @@ trait PBProductWriterImplicits {
     instance { (indexedValues: (FieldIndex, H) :: T, out: CodedOutputStream) =>
       val headIndex = indexedValues.head._1.values.head
       val headValue = indexedValues.head._2
-      head.writeTo(headIndex, headValue, out)
+      head.writeTo(headIndex, headValue, out, skipDefaultValue = true)
       tail.value.writeTo(indexedValues.tail, out)
     }
 

--- a/src/main/scala/pbdirect/PBProductWriter.scala
+++ b/src/main/scala/pbdirect/PBProductWriter.scala
@@ -30,11 +30,13 @@ trait PBProductWriterImplicits {
 
   implicit def consOneofWriter[H <: Coproduct, T <: HList](
       implicit head: PBOneofFieldWriter[H],
-      tail: Lazy[PBProductWriter[T]]): PBProductWriter[(FieldIndex, H) :: T] =
-    instance { (indexedValues: (FieldIndex, H) :: T, out: CodedOutputStream) =>
-      val headIndices = indexedValues.head._1.values
-      val headValue   = indexedValues.head._2
-      head.writeTo(headIndices, headValue, out)
+      tail: Lazy[PBProductWriter[T]]): PBProductWriter[(FieldIndex, Option[H]) :: T] =
+    instance { (indexedValues: (FieldIndex, Option[H]) :: T, out: CodedOutputStream) =>
+      indexedValues.head match {
+        case (headFieldIndex, Some(headValue)) =>
+          head.writeTo(headFieldIndex.values, headValue, out)
+        case _ => // skip writing the field
+      }
       tail.value.writeTo(indexedValues.tail, out)
     }
 

--- a/src/main/scala/pbdirect/PBProductWriter.scala
+++ b/src/main/scala/pbdirect/PBProductWriter.scala
@@ -28,6 +28,16 @@ trait PBProductWriterImplicits {
       tail.value.writeTo(indexedValues.tail, out)
     }
 
+  implicit def consOneofWriter[H <: Coproduct, T <: HList](
+      implicit head: PBOneofFieldWriter[H],
+      tail: Lazy[PBProductWriter[T]]): PBProductWriter[(FieldIndex, H) :: T] =
+    instance { (indexedValues: (FieldIndex, H) :: T, out: CodedOutputStream) =>
+      val headIndices = indexedValues.head._1.values
+      val headValue   = indexedValues.head._2
+      head.writeTo(headIndices, headValue, out)
+      tail.value.writeTo(indexedValues.tail, out)
+    }
+
 }
 
 object PBProductWriter extends PBProductWriterImplicits {

--- a/src/test/scala/pbdirect/PBFieldWriterSpec.scala
+++ b/src/test/scala/pbdirect/PBFieldWriterSpec.scala
@@ -10,7 +10,7 @@ class PBFieldWriterSpec extends AnyWordSpecLike with Matchers {
   def write[A](value: A)(implicit writer: PBFieldWriter[A]): Array[Byte] = {
     val buffer = new ByteArrayOutputStream()
     val out    = CodedOutputStream.newInstance(buffer)
-    writer.writeTo(1, value, out)
+    writer.writeTo(1, value, out, skipDefaultValue = true)
     out.flush()
     buffer.toByteArray()
   }

--- a/src/test/scala/pbdirect/PBMessageReaderSpec.scala
+++ b/src/test/scala/pbdirect/PBMessageReaderSpec.scala
@@ -2,6 +2,8 @@ package pbdirect
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
+import shapeless._
+import shapeless.syntax.inject._
 
 class PBMessageReaderSpec extends AnyWordSpecLike with Matchers {
 
@@ -49,15 +51,6 @@ class PBMessageReaderSpec extends AnyWordSpecLike with Matchers {
       val bytes = Array[Byte](10, 5, 72, 101, 108, 108, 111, 18, 2, 8, 11)
       bytes.pbTo[OuterMessage] shouldBe OuterMessage(Some("Hello"), Some(InnerMessage(Some(11))))
     }
-    "read a sealed trait from Protobuf" in {
-      sealed trait Message
-      case class IntMessage(@pbIndex(1) value: Option[Int])       extends Message
-      case class StringMessage(@pbIndex(1) value: Option[String]) extends Message
-      val intBytes    = Array[Byte](8, 5)
-      val stringBytes = Array[Byte](10, 5, 72, 101, 108, 108, 111)
-      intBytes.pbTo[Message] shouldBe IntMessage(Some(5))
-      stringBytes.pbTo[Message] shouldBe StringMessage(Some("Hello"))
-    }
     "read a message with repeated nested message from Protobuf" in {
       case class Metric(
           @pbIndex(1) name: String,
@@ -83,6 +76,28 @@ class PBMessageReaderSpec extends AnyWordSpecLike with Matchers {
       case class MultiMessage(@pbIndex(1) text: Option[String], @pbIndex(3) number: Option[Int])
       val bytes = Array[Byte](10, 5, 72, 101, 108, 108, 111, 24, 3)
       bytes.pbTo[MultiMessage] shouldBe MultiMessage(Some("Hello"), Some(3))
+    }
+
+    type Cop = Int :+: String :+: Boolean :+: CNil
+    case class CoproductMessage(
+        @pbIndex(1) a: Int,
+        @pbIndex(3, 5, 7) b: Cop
+    )
+    "read a properly annotated message with a Coproduct field (1st branch)" in {
+      val bytes = Array[Byte](8, 5, 24, 9)
+      bytes.pbTo[CoproductMessage] shouldBe CoproductMessage(5, 9.inject[Cop])
+    }
+    "read a properly annotated message with a Coproduct field (2nd branch)" in {
+      val bytes = Array[Byte](8, 5, 42, 5, 72, 101, 108, 108, 111)
+      bytes.pbTo[CoproductMessage] shouldBe CoproductMessage(5, "Hello".inject[Cop])
+    }
+    "read a properly annotated message with a Coproduct field (3rd branch)" in {
+      val bytes = Array[Byte](8, 5, 56, 1)
+      bytes.pbTo[CoproductMessage] shouldBe CoproductMessage(5, true.inject[Cop])
+    }
+    "read a oneof field with the default value" in {
+      val bytes = Array[Byte](8, 5, 42, 0)
+      bytes.pbTo[CoproductMessage] shouldBe CoproductMessage(5, "".inject[Cop])
     }
   }
 }

--- a/src/test/scala/pbdirect/PBMessageWriterSpec.scala
+++ b/src/test/scala/pbdirect/PBMessageWriterSpec.scala
@@ -103,5 +103,14 @@ class PBMessageWriterSpec extends AnyWordSpecLike with Matchers {
       val message = CoproductMessage(5, "Hello".inject[Cop])
       message.toPB shouldBe Array[Byte](8, 5, 42, 5, 72, 101, 108, 108, 111)
     }
+    "write a oneof field even if it has the default value" in {
+      type Cop = Int :+: String :+: Boolean :+: CNil
+      case class CoproductMessage(
+          @pbIndex(1) a: Int,
+          @pbIndex(3, 5, 7) b: Cop
+      )
+      val message = CoproductMessage(5, "".inject[Cop])
+      message.toPB shouldBe Array[Byte](8, 5, 42, 0)
+    }
   }
 }

--- a/src/test/scala/pbdirect/PBMessageWriterSpec.scala
+++ b/src/test/scala/pbdirect/PBMessageWriterSpec.scala
@@ -2,6 +2,8 @@ package pbdirect
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
+import shapeless._
+import shapeless.syntax.inject._
 
 class PBMessageWriterSpec extends AnyWordSpecLike with Matchers {
   "PBMessageWriter" should {
@@ -69,15 +71,6 @@ class PBMessageWriterSpec extends AnyWordSpecLike with Matchers {
       val message = OuterMessage(Some("Hello"), None)
       message.toPB shouldBe Array[Byte](10, 5, 72, 101, 108, 108, 111)
     }
-    "write a sealed trait to Protobuf" in {
-      sealed trait Message
-      case class IntMessage(@pbIndex(1) value: Option[Int])       extends Message
-      case class StringMessage(@pbIndex(1) value: Option[String]) extends Message
-      val intMessage: Message    = IntMessage(Some(5))
-      val stringMessage: Message = StringMessage(Some("Hello"))
-      intMessage.toPB shouldBe Array[Byte](8, 5)
-      stringMessage.toPB shouldBe Array[Byte](10, 5, 72, 101, 108, 108, 111)
-    }
     "write a message with repeated nested message in Protobuf" in {
       case class Metric(
           @pbIndex(1) metric: String,
@@ -100,6 +93,15 @@ class PBMessageWriterSpec extends AnyWordSpecLike with Matchers {
       )
       val message = AnnotatedMessage("Hello", 3)
       message.toPB shouldBe Array[Byte](10, 5, 72, 101, 108, 108, 111, 24, 3)
+    }
+    "write a properly annotated message with a Coproduct field to Protobuf" in {
+      type Cop = Int :+: String :+: Boolean :+: CNil
+      case class CoproductMessage(
+          @pbIndex(1) a: Int,
+          @pbIndex(3, 5, 7) b: Cop
+      )
+      val message = CoproductMessage(5, "Hello".inject[Cop])
+      message.toPB shouldBe Array[Byte](8, 5, 42, 5, 72, 101, 108, 108, 111)
     }
   }
 }

--- a/src/test/scala/pbdirect/PBMessageWriterSpec.scala
+++ b/src/test/scala/pbdirect/PBMessageWriterSpec.scala
@@ -98,22 +98,22 @@ class PBMessageWriterSpec extends AnyWordSpecLike with Matchers {
     type Cop = Int :+: String :+: Boolean :+: CNil
     case class CoproductMessage(
         @pbIndex(1) a: Int,
-        @pbIndex(3, 5, 7) b: Cop
+        @pbIndex(3, 5, 7) b: Option[Cop]
     )
     "write a properly annotated message with a Coproduct field (1st branch)" in {
-      val message = CoproductMessage(5, 9.inject[Cop])
+      val message = CoproductMessage(5, Some(9.inject[Cop]))
       message.toPB shouldBe Array[Byte](8, 5, 24, 9)
     }
     "write a properly annotated message with a Coproduct field (2nd branch)" in {
-      val message = CoproductMessage(5, "Hello".inject[Cop])
+      val message = CoproductMessage(5, Some("Hello".inject[Cop]))
       message.toPB shouldBe Array[Byte](8, 5, 42, 5, 72, 101, 108, 108, 111)
     }
     "write a properly annotated message with a Coproduct field (3rd branch)" in {
-      val message = CoproductMessage(5, true.inject[Cop])
+      val message = CoproductMessage(5, Some(true.inject[Cop]))
       message.toPB shouldBe Array[Byte](8, 5, 56, 1)
     }
     "write a oneof field even if it has the default value" in {
-      val message = CoproductMessage(5, "".inject[Cop])
+      val message = CoproductMessage(5, Some("".inject[Cop]))
       message.toPB shouldBe Array[Byte](8, 5, 42, 0)
     }
   }

--- a/src/test/scala/pbdirect/PBMessageWriterSpec.scala
+++ b/src/test/scala/pbdirect/PBMessageWriterSpec.scala
@@ -94,21 +94,25 @@ class PBMessageWriterSpec extends AnyWordSpecLike with Matchers {
       val message = AnnotatedMessage("Hello", 3)
       message.toPB shouldBe Array[Byte](10, 5, 72, 101, 108, 108, 111, 24, 3)
     }
-    "write a properly annotated message with a Coproduct field to Protobuf" in {
-      type Cop = Int :+: String :+: Boolean :+: CNil
-      case class CoproductMessage(
-          @pbIndex(1) a: Int,
-          @pbIndex(3, 5, 7) b: Cop
-      )
+
+    type Cop = Int :+: String :+: Boolean :+: CNil
+    case class CoproductMessage(
+        @pbIndex(1) a: Int,
+        @pbIndex(3, 5, 7) b: Cop
+    )
+    "write a properly annotated message with a Coproduct field (1st branch)" in {
+      val message = CoproductMessage(5, 9.inject[Cop])
+      message.toPB shouldBe Array[Byte](8, 5, 24, 9)
+    }
+    "write a properly annotated message with a Coproduct field (2nd branch)" in {
       val message = CoproductMessage(5, "Hello".inject[Cop])
       message.toPB shouldBe Array[Byte](8, 5, 42, 5, 72, 101, 108, 108, 111)
     }
+    "write a properly annotated message with a Coproduct field (3rd branch)" in {
+      val message = CoproductMessage(5, true.inject[Cop])
+      message.toPB shouldBe Array[Byte](8, 5, 56, 1)
+    }
     "write a oneof field even if it has the default value" in {
-      type Cop = Int :+: String :+: Boolean :+: CNil
-      case class CoproductMessage(
-          @pbIndex(1) a: Int,
-          @pbIndex(3, 5, 7) b: Cop
-      )
       val message = CoproductMessage(5, "".inject[Cop])
       message.toPB shouldBe Array[Byte](8, 5, 42, 0)
     }

--- a/src/test/scala/pbdirect/PBScalarValueWriterSpec.scala
+++ b/src/test/scala/pbdirect/PBScalarValueWriterSpec.scala
@@ -11,7 +11,7 @@ class PBScalarValueWriterSpec extends AnyWordSpecLike with Matchers {
     val fieldWriter = implicitly[PBFieldWriter[A]]
     val buffer      = new ByteArrayOutputStream()
     val out         = CodedOutputStream.newInstance(buffer)
-    fieldWriter.writeTo(1, value, out)
+    fieldWriter.writeTo(1, value, out, skipDefaultValue = true)
     out.flush()
     buffer.toByteArray()
   }

--- a/src/test/scala/pbdirect/RoundTripSpec.scala
+++ b/src/test/scala/pbdirect/RoundTripSpec.scala
@@ -28,7 +28,8 @@ class RoundTripSpec extends AnyFlatSpec with Checkers {
 
   "round trip to protobuf and back" should "result in a message equivalent to the original" in check {
     forAllNoShrink { (message: MessageThree) =>
-      val roundtripped = message.toPB.pbTo[MessageThree]
+      val serialized   = message.toPB
+      val roundtripped = serialized.pbTo[MessageThree]
 
       val label = s"""|
         |message before roundtrip = $message
@@ -56,7 +57,8 @@ object RoundTripSpec {
       @pbIndex(5) int: Int,
       @pbIndex(10) string: String,
       @pbIndex(15) emptyMessage: EmptyMessage,
-      @pbIndex(20) nestedMessage: MessageOne
+      @pbIndex(20) nestedMessage: MessageOne,
+      @pbIndex(21, 22, 23) coproduct: Option[Int :+: String :+: MessageOne :+: CNil]
   )
 
   case class MessageThree(


### PR DESCRIPTION
Support for reading/writing shapeless coproducts as protobuf `oneof` fields.

The field must be annotated with a `@pbIndex` annotation containing the field numbers for each branch of the coproduct. Also the coproduct type must be wrapped in `Option` so that we can handle missing fields sensibly.

e.g.

```scala
case class CoproductMessage(
  @pbIndex(1) a: Int,
  @pbIndex(2, 3, 4) b: Option[String :+: Boolean :+: SomeOtherMessage :+: CNil]
)
```

Also updated the readme to document both this feature and the new support for default values/missing fields.

This PR also removes a feature that I didn't think should exist: reading and writing sealed traits of messages, e.g.

```scala
sealed trait CouldBeThisOrThat
case class This(a: Int, b: String) extends CouldBeThisOrThat
case class That(c: Boolean) extends CouldBeThisOrThat
```

The same functionality can now be achieved more safely and protobuf-compliantly using a `oneof` field.