### PR TITLE
Packed repeated fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,19 @@ case class MyMessage(instant: Instant)
 
 and you use the `instantReader` defined earlier, reading a message with the `instant` field missing would result in `1970-01-01T00:00:00Z`.
 
+## Packed repeated fields
+
+Primitive repeated fields (ints, floats, doubles, enums and booleans) are
+encoded using the protobuf packed encoding by default.
+
+This behaviour can be overriden using the `@pbUnpacked` annotation:
+
+```scala
+case class UnpackedMessage(
+  @pbUnpacked() ints: List[Int]
+)
+```
+
 [comment]: # (Start Copyright)
 # Copyright
 

--- a/src/main/scala/pbdirect/FieldModifiers.scala
+++ b/src/main/scala/pbdirect/FieldModifiers.scala
@@ -1,0 +1,9 @@
+package pbdirect
+
+/**
+ * Modifiers for how a field should be encoded,
+ * derived from annotations such as @pbUnpacked.
+ */
+private[pbdirect] final case class FieldModifiers(
+    unpacked: Boolean
+)

--- a/src/main/scala/pbdirect/PBFieldWriter.scala
+++ b/src/main/scala/pbdirect/PBFieldWriter.scala
@@ -1,30 +1,29 @@
 package pbdirect
 
 import com.google.protobuf.CodedOutputStream
+import java.io.ByteArrayOutputStream
 
 trait PBFieldWriter[A] {
 
-  /**
-   * @param skipDefaultValue If true, the field should not be written if it is a scalar field with the default value for its type
-   */
-  def writeTo(index: Int, value: A, out: CodedOutputStream, skipDefaultValue: Boolean): Unit
+  def writeTo(index: Int, value: A, out: CodedOutputStream, flags: PBFieldWriter.Flags): Unit
+
 }
 
 trait PBFieldWriterImplicits {
 
-  def instance[A](f: (Int, A, CodedOutputStream, Boolean) => Unit): PBFieldWriter[A] =
+  def instance[A](f: (Int, A, CodedOutputStream, PBFieldWriter.Flags) => Unit): PBFieldWriter[A] =
     new PBFieldWriter[A] {
       override def writeTo(
           index: Int,
           value: A,
           out: CodedOutputStream,
-          skipDefaultValue: Boolean): Unit =
-        f(index, value, out, skipDefaultValue)
+          flags: PBFieldWriter.Flags): Unit =
+        f(index, value, out, flags)
     }
 
   implicit def scalarWriter[A](implicit writer: PBScalarValueWriter[A]): PBFieldWriter[A] =
-    instance { (index: Int, value: A, out: CodedOutputStream, skipDefaultValue: Boolean) =>
-      if (skipDefaultValue && writer.isDefault(value)) {
+    instance { (index: Int, value: A, out: CodedOutputStream, flags: PBFieldWriter.Flags) =>
+      if (flags.skipDefaultValue && writer.isDefault(value)) {
         // skip the field
       } else {
         out.writeTag(index, writer.wireType)
@@ -33,24 +32,33 @@ trait PBFieldWriterImplicits {
     }
 
   implicit def optionWriter[A](implicit writer: PBFieldWriter[A]): PBFieldWriter[Option[A]] =
-    instance { (index: Int, option: Option[A], out: CodedOutputStream, skipDefaultValue: Boolean) =>
-      option.foreach(v => writer.writeTo(index, v, out, skipDefaultValue))
+    instance {
+      (index: Int, option: Option[A], out: CodedOutputStream, flags: PBFieldWriter.Flags) =>
+        option.foreach(v => writer.writeTo(index, v, out, flags))
     }
 
   implicit def listWriter[A](implicit writer: PBScalarValueWriter[A]): PBFieldWriter[List[A]] =
-    instance { (index: Int, list: List[A], out: CodedOutputStream, skipDefaultValue: Boolean) =>
-      // TODO when we support writing packed repeated fields,
-      // we need to check if the list is empty and skip the field completely
-      list.foreach { value =>
-        out.writeTag(index, writer.wireType)
-        writer.writeWithoutTag(value, out)
+    instance { (index: Int, list: List[A], out: CodedOutputStream, flags: PBFieldWriter.Flags) =>
+      if (writer.canBePacked && !flags.unpacked) {
+        if (list.nonEmpty) {
+          val buffer    = new ByteArrayOutputStream()
+          val packedOut = CodedOutputStream.newInstance(buffer)
+          list.foreach(value => writer.writeWithoutTag(value, packedOut))
+          packedOut.flush()
+          out.writeByteArray(index, buffer.toByteArray)
+        }
+      } else {
+        list.foreach { value =>
+          out.writeTag(index, writer.wireType)
+          writer.writeWithoutTag(value, out)
+        }
       }
     }
 
   implicit def mapWriter[K, V](
       implicit writer: PBFieldWriter[List[(K, V)]]): PBFieldWriter[Map[K, V]] =
-    instance { (index: Int, value: Map[K, V], out: CodedOutputStream, skipDefaultValue: Boolean) =>
-      writer.writeTo(index, value.toList, out, skipDefaultValue)
+    instance { (index: Int, value: Map[K, V], out: CodedOutputStream, flags: PBFieldWriter.Flags) =>
+      writer.writeTo(index, value.toList, out, flags)
     }
 
   implicit def collectionMapWriter[K, V](
@@ -60,17 +68,28 @@ trait PBFieldWriterImplicits {
           index: Int,
           value: collection.Map[K, V],
           out: CodedOutputStream,
-          skipDefaultValue: Boolean) =>
-        writer.writeTo(index, value.toList, out, skipDefaultValue)
+          flags: PBFieldWriter.Flags) =>
+        writer.writeTo(index, value.toList, out, flags)
     }
 
   implicit def seqWriter[A](implicit writer: PBFieldWriter[List[A]]): PBFieldWriter[Seq[A]] =
-    instance { (index: Int, value: Seq[A], out: CodedOutputStream, skipDefaultValue: Boolean) =>
-      writer.writeTo(index, value.toList, out, skipDefaultValue)
+    instance { (index: Int, value: Seq[A], out: CodedOutputStream, flags: PBFieldWriter.Flags) =>
+      writer.writeTo(index, value.toList, out, flags)
     }
 
 }
 
 object PBFieldWriter extends PBFieldWriterImplicits {
+
   def apply[A: PBFieldWriter]: PBFieldWriter[A] = implicitly
+
+  /**
+   * @param skipDefaultValue If true, the field should not be written if it is a scalar field with the default value for its type
+   * @param unpacked If true, the field should be written using unpacked encoding if it is a primitive repeated field
+   */
+  case class Flags(
+      skipDefaultValue: Boolean,
+      unpacked: Boolean
+  )
+
 }

--- a/src/main/scala/pbdirect/PBFormat.scala
+++ b/src/main/scala/pbdirect/PBFormat.scala
@@ -25,6 +25,7 @@ object PBFormat extends PBFormatImplicits {
       override def wireType: Int                    = writer.wireType
       override def isDefault(value: A): Boolean     = writer.isDefault(value)
       override def defaultValue: A                  = reader.defaultValue
+      override def canBePacked: Boolean             = reader.canBePacked
       override def writeWithoutTag(value: A, out: CodedOutputStream): Unit =
         writer.writeWithoutTag(value, out)
     }

--- a/src/main/scala/pbdirect/PBOneofFieldWriter.scala
+++ b/src/main/scala/pbdirect/PBOneofFieldWriter.scala
@@ -4,30 +4,44 @@ import com.google.protobuf.CodedOutputStream
 import shapeless._
 
 trait PBOneofFieldWriter[A <: Coproduct] {
-  def writeTo(indices: List[Int], value: A, out: CodedOutputStream): Unit
+  def writeTo(
+      indices: List[Int],
+      value: A,
+      out: CodedOutputStream,
+      flags: PBFieldWriter.Flags): Unit
 }
 
 trait PBOneofFieldWriterImplicits {
 
   def instance[A <: Coproduct](
-      f: (List[Int], A, CodedOutputStream) => Unit): PBOneofFieldWriter[A] =
+      f: (List[Int], A, CodedOutputStream, PBFieldWriter.Flags) => Unit): PBOneofFieldWriter[A] =
     new PBOneofFieldWriter[A] {
-      override def writeTo(indices: List[Int], value: A, out: CodedOutputStream): Unit =
-        f(indices, value, out)
+      override def writeTo(
+          indices: List[Int],
+          value: A,
+          out: CodedOutputStream,
+          flags: PBFieldWriter.Flags): Unit =
+        f(indices, value, out, flags)
     }
 
   implicit val cnilWriter: PBOneofFieldWriter[CNil] = instance(
-    (_, _, _) => throw new IllegalStateException("Cannot write CNil"))
+    (_, _, _, _) => throw new IllegalStateException("Cannot write CNil"))
 
   implicit def cconsWriter[H, T <: Coproduct](
       implicit
       headWriter: PBFieldWriter[H],
       tailWriter: Lazy[PBOneofFieldWriter[T]]): PBOneofFieldWriter[H :+: T] =
-    instance { (indices: List[Int], value: H :+: T, out: CodedOutputStream) =>
-      value match {
-        case Inl(h) => headWriter.writeTo(indices.head, h, out, skipDefaultValue = false)
-        case Inr(t) => tailWriter.value.writeTo(indices.tail, t, out)
-      }
+    instance {
+      (indices: List[Int], value: H :+: T, out: CodedOutputStream, flags: PBFieldWriter.Flags) =>
+        value match {
+          case Inl(h) =>
+            // We should always write a oneof field, even if it's the default value,
+            // so the reader knows which field was set
+            val updatedFlags = flags.copy(skipDefaultValue = false)
+            headWriter.writeTo(indices.head, h, out, updatedFlags)
+          case Inr(t) =>
+            tailWriter.value.writeTo(indices.tail, t, out, flags)
+        }
     }
 
 }

--- a/src/main/scala/pbdirect/PBProductWriter.scala
+++ b/src/main/scala/pbdirect/PBProductWriter.scala
@@ -20,24 +20,30 @@ trait PBProductWriterImplicits {
 
   implicit def consWriter[H, T <: HList](
       implicit head: PBFieldWriter[H],
-      tail: Lazy[PBProductWriter[T]]): PBProductWriter[(FieldIndex, H) :: T] =
-    instance { (indexedValues: (FieldIndex, H) :: T, out: CodedOutputStream) =>
-      val headIndex = indexedValues.head._1.values.head
-      val headValue = indexedValues.head._2
-      head.writeTo(headIndex, headValue, out, skipDefaultValue = true)
+      tail: Lazy[PBProductWriter[T]]): PBProductWriter[(FieldIndex, H, FieldModifiers) :: T] =
+    instance { (indexedValues: (FieldIndex, H, FieldModifiers) :: T, out: CodedOutputStream) =>
+      val headIndex     = indexedValues.head._1.values.head
+      val headValue     = indexedValues.head._2
+      val headModifiers = indexedValues.head._3
+      val flags         = PBFieldWriter.Flags(skipDefaultValue = true, unpacked = headModifiers.unpacked)
+      head.writeTo(headIndex, headValue, out, flags)
       tail.value.writeTo(indexedValues.tail, out)
     }
 
   implicit def consOneofWriter[H <: Coproduct, T <: HList](
       implicit head: PBOneofFieldWriter[H],
-      tail: Lazy[PBProductWriter[T]]): PBProductWriter[(FieldIndex, Option[H]) :: T] =
-    instance { (indexedValues: (FieldIndex, Option[H]) :: T, out: CodedOutputStream) =>
-      indexedValues.head match {
-        case (headFieldIndex, Some(headValue)) =>
-          head.writeTo(headFieldIndex.values, headValue, out)
-        case _ => // skip writing the field
-      }
-      tail.value.writeTo(indexedValues.tail, out)
+      tail: Lazy[PBProductWriter[T]]): PBProductWriter[
+    (FieldIndex, Option[H], FieldModifiers) :: T] =
+    instance {
+      (indexedValues: (FieldIndex, Option[H], FieldModifiers) :: T, out: CodedOutputStream) =>
+        indexedValues.head match {
+          case (headFieldIndex, Some(headValue), headModifiers) =>
+            val flags =
+              PBFieldWriter.Flags(skipDefaultValue = true, unpacked = headModifiers.unpacked)
+            head.writeTo(headFieldIndex.values, headValue, out, flags)
+          case _ => // skip writing the field
+        }
+        tail.value.writeTo(indexedValues.tail, out)
     }
 
 }

--- a/src/main/scala/pbdirect/PBScalarValueReader.scala
+++ b/src/main/scala/pbdirect/PBScalarValueReader.scala
@@ -6,31 +6,39 @@ import shapeless._
 import enumeratum.values.{IntEnum, IntEnumEntry}
 
 trait PBScalarValueReader[A] {
+  /**
+   * The default value to use as a fallback if the field is missing from the message.
+   */
   def defaultValue: A
+
+  /**
+   * Whether it's possible for a repeated field of this type to be encoded using the packed encoding.
+   * This is only possible for "primitive" protobuf types:
+   * int{32,64}, {u,s}int{32,64}, bool, enum, fixed32, sfixed32, float, fixed64, sfixed64, double
+   */
+  def canBePacked: Boolean
+
+  /**
+   * Read a value of type A from the current point in the input stream.
+   */
   def read(input: CodedInputStream): A
 }
 
 trait PBScalarValueReaderImplicits_1 {
 
-  def instance[A](default: A)(f: CodedInputStream => A): PBScalarValueReader[A] =
-    new PBScalarValueReader[A] {
-      override def defaultValue: A                  = default
-      override def read(input: CodedInputStream): A = f(input)
-    }
-
   implicit def embeddedMessageReader[A](
-      implicit reader: PBMessageReader[A]): PBScalarValueReader[A] = {
-
-    // To construct a default instance of the message
-    // we decode a byte array of length zero,
-    // i.e. with all of the message's fields missing
-    val default: A = reader.read(Array[Byte]())
-
-    instance(default) { (input: CodedInputStream) =>
-      val bytes = input.readByteArray()
-      reader.read(bytes)
+      implicit reader: PBMessageReader[A]): PBScalarValueReader[A] =
+    new PBScalarValueReader[A] {
+      // To construct a default instance of the message
+      // we decode a byte array of length zero,
+      // i.e. with all of the message's fields missing
+      val defaultValue: A      = reader.read(Array[Byte]())
+      def canBePacked: Boolean = false
+      def read(input: CodedInputStream): A = {
+        val bytes = input.readByteArray()
+        reader.read(bytes)
+      }
     }
-  }
 
 }
 
@@ -38,47 +46,58 @@ trait PBScalarValueReaderImplicits extends PBScalarValueReaderImplicits_1 {
 
   implicit object BooleanReader$ extends PBScalarValueReader[Boolean] {
     override def defaultValue: Boolean                  = false
+    override def canBePacked: Boolean                   = true
     override def read(input: CodedInputStream): Boolean = input.readBool()
   }
   // Stored as variants, but larger in memory: https://groups.google.com/forum/#!topic/protobuf/Er39mNGnRWU
   implicit object ByteReader$ extends PBScalarValueReader[Byte] {
     override def defaultValue: Byte                  = 0.toByte
+    override def canBePacked: Boolean                = true
     override def read(input: CodedInputStream): Byte = input.readInt32().toByte
   }
   // Stored as variants, but larger in memory: https://groups.google.com/forum/#!topic/protobuf/Er39mNGnRWU
   implicit object ShortReader$ extends PBScalarValueReader[Short] {
     override def defaultValue: Short                  = 0.toShort
+    override def canBePacked: Boolean                 = true
     override def read(input: CodedInputStream): Short = input.readInt32().toShort
   }
   implicit object IntReader$ extends PBScalarValueReader[Int] {
     override def defaultValue: Int                  = 0
+    override def canBePacked: Boolean               = true
     override def read(input: CodedInputStream): Int = input.readInt32()
   }
   implicit object LongReader$ extends PBScalarValueReader[Long] {
     override def defaultValue: Long                  = 0L
+    override def canBePacked: Boolean                = true
     override def read(input: CodedInputStream): Long = input.readInt64()
   }
   implicit object FloatReader$ extends PBScalarValueReader[Float] {
     override def defaultValue: Float                  = 0.0F
+    override def canBePacked: Boolean                 = true
     override def read(input: CodedInputStream): Float = input.readFloat()
   }
   implicit object DoubleReader$ extends PBScalarValueReader[Double] {
     override def defaultValue: Double                  = 0.0
+    override def canBePacked: Boolean                  = true
     override def read(input: CodedInputStream): Double = input.readDouble()
   }
   implicit object StringReader$ extends PBScalarValueReader[String] {
     override def defaultValue: String                  = ""
+    override def canBePacked: Boolean                  = false
     override def read(input: CodedInputStream): String = input.readString()
   }
   implicit object BytesReader$ extends PBScalarValueReader[Array[Byte]] {
     override def defaultValue: Array[Byte]                  = Array()
+    override def canBePacked: Boolean                       = false
     override def read(input: CodedInputStream): Array[Byte] = input.readByteArray()
   }
 
   implicit object FunctorReader extends Functor[PBScalarValueReader] {
     override def map[A, B](reader: PBScalarValueReader[A])(f: A => B): PBScalarValueReader[B] =
-      instance(default = f(reader.defaultValue)) { (input: CodedInputStream) =>
-        f(reader.read(input))
+      new PBScalarValueReader[B] {
+        val defaultValue: B                  = f(reader.defaultValue)
+        def canBePacked: Boolean             = reader.canBePacked
+        def read(input: CodedInputStream): B = f(reader.read(input))
       }
   }
 
@@ -87,18 +106,21 @@ trait PBScalarValueReaderImplicits extends PBScalarValueReaderImplicits_1 {
       values: Enum.Values[A],
       ordering: Ordering[A],
       reader: PBScalarValueReader[Int]): PBScalarValueReader[A] =
-    instance(default = Enum.fromInt[A](0)) { (input: CodedInputStream) =>
-      Enum.fromInt[A](reader.read(input))
+    new PBScalarValueReader[A] {
+      val defaultValue: A                  = Enum.fromInt[A](0)
+      def canBePacked: Boolean             = true
+      def read(input: CodedInputStream): A = Enum.fromInt[A](reader.read(input))
     }
 
   implicit def enumerationReader[E <: Enumeration](
       implicit
       reader: PBScalarValueReader[Int],
       gen: Generic.Aux[E, HNil]): PBScalarValueReader[E#Value] = {
-    val enum    = gen.from(HNil)
-    val default = enum(0)
-    instance[E#Value](default) { (input: CodedInputStream) =>
-      enum(reader.read(input))
+    val enum = gen.from(HNil)
+    new PBScalarValueReader[E#Value] {
+      val defaultValue: E#Value                  = enum(0)
+      def canBePacked: Boolean                   = true
+      def read(input: CodedInputStream): E#Value = enum(reader.read(input))
     }
   }
 
@@ -106,8 +128,10 @@ trait PBScalarValueReaderImplicits extends PBScalarValueReaderImplicits_1 {
       implicit
       reader: PBScalarValueReader[Int],
       enum: IntEnum[E]): PBScalarValueReader[E] =
-    instance(default = enum.withValue(0)) { (input: CodedInputStream) =>
-      enum.withValue(reader.read(input))
+    new PBScalarValueReader[E] {
+      val defaultValue: E                  = enum.withValue(0)
+      def canBePacked: Boolean             = true
+      def read(input: CodedInputStream): E = enum.withValue(reader.read(input))
     }
 
   implicit def keyValuePairReader[K, V](
@@ -115,15 +139,19 @@ trait PBScalarValueReaderImplicits extends PBScalarValueReaderImplicits_1 {
       valueReader: PBScalarValueReader[V]): PBScalarValueReader[(K, V)] = {
     val defaultKey   = keyReader.defaultValue
     val defaultValue = valueReader.defaultValue
-    val default      = (defaultKey, defaultValue)
-    instance(default) { (input: CodedInputStream) =>
-      val bytes = input.readByteArray()
-      val in    = CodedInputStream.newInstance(bytes)
-      in.readTag()
-      val key = keyReader.read(in)
-      in.readTag()
-      val value = valueReader.read(in)
-      (key, value)
+    val defaultPair  = (defaultKey, defaultValue)
+    new PBScalarValueReader[(K, V)] {
+      val defaultValue: (K, V) = defaultPair
+      def canBePacked: Boolean = false
+      def read(input: CodedInputStream): (K, V) = {
+        val bytes = input.readByteArray()
+        val in    = CodedInputStream.newInstance(bytes)
+        in.readTag()
+        val key = keyReader.read(in)
+        in.readTag()
+        val value = valueReader.read(in)
+        (key, value)
+      }
     }
   }
 

--- a/src/main/scala/pbdirect/PBScalarValueReader.scala
+++ b/src/main/scala/pbdirect/PBScalarValueReader.scala
@@ -6,6 +6,7 @@ import shapeless._
 import enumeratum.values.{IntEnum, IntEnumEntry}
 
 trait PBScalarValueReader[A] {
+
   /**
    * The default value to use as a fallback if the field is missing from the message.
    */

--- a/src/main/scala/pbdirect/PBScalarValueWriter.scala
+++ b/src/main/scala/pbdirect/PBScalarValueWriter.scala
@@ -23,6 +23,14 @@ trait PBScalarValueWriter[A] {
   def wireType: Int
 
   /**
+   * Whether repeated fields of this type can be packed.
+   * Primitive repeated fields (ints, floats, bools and enums)
+   * can be packed, and should be, unless overriden using a @pbUnpacked annotation.
+   */
+  def canBePacked: Boolean =
+    Set(WIRETYPE_VARINT, WIRETYPE_FIXED32, WIRETYPE_FIXED64) contains wireType
+
+  /**
    * Whether the given value would be encoded as the default value
    * for its corresponding protobuf scalar type.
    *

--- a/src/main/scala/pbdirect/pbUnpacked.scala
+++ b/src/main/scala/pbdirect/pbUnpacked.scala
@@ -1,0 +1,20 @@
+package pbdirect
+
+/**
+ * An annotation to specify that a primitive repeated field
+ * should **not** be encoded using the protobuf packed encoding.
+ *
+ * e.g.
+ *
+ * {{{
+ * case class MyMessage(
+ *   @pbUnpacked() numbers: List[Int]
+ * )
+ * }}}
+ *
+ * Unless annotated with @pbUnpacked, all primitive repeated fields
+ * (ints, floats, booleans and enums) will be packed by default.
+ * This is the standard proto3 behaviour.
+ *
+ */
+case class pbUnpacked()

--- a/src/test/scala/pbdirect/PBFieldReaderSpec.scala
+++ b/src/test/scala/pbdirect/PBFieldReaderSpec.scala
@@ -73,8 +73,16 @@ class PBFieldReaderSpec extends AnyWordSpecLike with Matchers {
       val bytes = Array[Byte](8, 11)
       PBFieldReader[Option[Int]].read(1, bytes) shouldBe Some(11)
     }
-    "read a repeated field from Protobuf" in {
+    "read an unpacked repeated field from Protobuf" in {
       val bytes = Array[Byte](8, 1, 8, 2, 8, 3, 8, 4)
+      PBFieldReader[List[Int]].read(1, bytes) shouldBe 1 :: 2 :: 3 :: 4 :: Nil
+    }
+    "read a packed repeated field from Protobuf" in {
+      val bytes = Array[Byte](10, 4, 1, 2, 3, 4)
+      PBFieldReader[List[Int]].read(1, bytes) shouldBe 1 :: 2 :: 3 :: 4 :: Nil
+    }
+    "read a packed repeated field split into multiple key-value pairs" in {
+      val bytes = Array[Byte](10, 2, 1, 2, 10, 2, 3, 4)
       PBFieldReader[List[Int]].read(1, bytes) shouldBe 1 :: 2 :: 3 :: 4 :: Nil
     }
     "read a Seq from Protobuf" in {

--- a/src/test/scala/pbdirect/PBMessageWriterSpec.scala
+++ b/src/test/scala/pbdirect/PBMessageWriterSpec.scala
@@ -42,8 +42,13 @@ class PBMessageWriterSpec extends AnyWordSpecLike with Matchers {
       val message = MultiMessage(Some("Hello"), Some(3))
       message.toPB shouldBe Array[Byte](10, 5, 72, 101, 108, 108, 111, 16, 3)
     }
-    "write a message with repeated field to Protobuf" in {
+    "write a message with a packed repeated field to Protobuf" in {
       case class RepeatedMessage(@pbIndex(1) values: List[Int])
+      val message = RepeatedMessage(1 :: 2 :: 3 :: 4 :: Nil)
+      message.toPB shouldBe Array[Byte](10, 4, 1, 2, 3, 4)
+    }
+    "write a message with an unpacked repeated field to Protobuf" in {
+      case class RepeatedMessage(@pbIndex(1) @pbUnpacked() values: List[Int])
       val message = RepeatedMessage(1 :: 2 :: 3 :: 4 :: Nil)
       message.toPB shouldBe Array[Byte](8, 1, 8, 2, 8, 3, 8, 4)
     }

--- a/src/test/scala/pbdirect/PBScalarValueWriterSpec.scala
+++ b/src/test/scala/pbdirect/PBScalarValueWriterSpec.scala
@@ -11,7 +11,8 @@ class PBScalarValueWriterSpec extends AnyWordSpecLike with Matchers {
     val fieldWriter = implicitly[PBFieldWriter[A]]
     val buffer      = new ByteArrayOutputStream()
     val out         = CodedOutputStream.newInstance(buffer)
-    fieldWriter.writeTo(1, value, out, skipDefaultValue = true)
+    val flags       = PBFieldWriter.Flags(skipDefaultValue = true, unpacked = false)
+    fieldWriter.writeTo(1, value, out, flags)
     out.flush()
     buffer.toByteArray()
   }

--- a/src/test/scala/pbdirect/RoundTripSpec.scala
+++ b/src/test/scala/pbdirect/RoundTripSpec.scala
@@ -50,7 +50,8 @@ object RoundTripSpec {
   case class MessageOne(
       @pbIndex(1) optionalEmpty: Option[EmptyMessage],
       @pbIndex(2) boolean: Boolean,
-      @pbIndex(3) repeatedFloat: List[Float]
+      @pbIndex(3) repeatedFloat: List[Float],
+      @pbIndex(4) @pbUnpacked repeatedUnpackedFloat: List[Float]
   )
 
   case class MessageTwo(


### PR DESCRIPTION
* Support reading of [packed repeated fields](https://developers.google.com/protocol-buffers/docs/encoding#packed)
* Write primitive repeated fields using packed encoding by default
    * Add a `@pbUnpacked` annotation for overriding this behaviour