### PR TITLE
Support reading/writing of Eithers as oneof fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,10 +172,31 @@ message MyMessage {
 }
 ```
 
-There are a couple of restrictions:
+`oneof` fields with exactly two branches can also be encoded using `Either`. For example:
+
+```scala
+case class MyMessage(
+  @pbIndex(1) number: Int,
+  @pbIndex(2,3) either: Option[Either[String, Boolean]]
+)
+```
+
+is equivalent to:
+
+```protobuf
+message MyMessage {
+  int32 number = 1;
+  oneof either {
+    string b = 2;
+    bool c   = 3;
+  }
+}
+```
+
+Support for `oneof` fields comes with a couple of restrictions:
 
 * `oneof` fields must have a `@pbIndex` annotation containing the indices of each of the sub-fields
-* The type of `oneof` fields must be a Coproduct wrapped in `Option[_]`. This is so that pbdirect can set the value to `None` when the field is missing when reading a message from protobuf.
+* The type of `oneof` fields must be a Coproduct (or `Either`) wrapped in `Option[_]`. This is so that pbdirect can set the value to `None` when the field is missing when reading a message from protobuf.
 
 ## Default values and missing fields
 

--- a/src/main/scala/pbdirect/FieldIndex.scala
+++ b/src/main/scala/pbdirect/FieldIndex.scala
@@ -5,4 +5,4 @@ package pbdirect
  * It holds a list of indices in order to support 'oneof' fields,
  * which are encoded as shapeless Coproducts and have a different index for each branch.
  */
-private[pbdirect] final case class FieldIndex(values: List[Int])
+final case class FieldIndex(values: List[Int])

--- a/src/main/scala/pbdirect/FieldModifiers.scala
+++ b/src/main/scala/pbdirect/FieldModifiers.scala
@@ -4,6 +4,6 @@ package pbdirect
  * Modifiers for how a field should be encoded,
  * derived from annotations such as @pbUnpacked.
  */
-private[pbdirect] final case class FieldModifiers(
+final case class FieldModifiers(
     unpacked: Boolean
 )

--- a/src/main/scala/pbdirect/PBProductReader.scala
+++ b/src/main/scala/pbdirect/PBProductReader.scala
@@ -18,7 +18,7 @@ trait PBProductReaderImplicits {
       HNil
   }
 
-  implicit def consProductReader[H, T <: HList, IT <: HList](
+  implicit def hconsProductReader[H, T <: HList, IT <: HList](
       implicit
       head: PBFieldReader[H],
       tail: Lazy[PBProductReader[T, IT]]): PBProductReader[H :: T, FieldIndex :: IT] =
@@ -26,12 +26,24 @@ trait PBProductReaderImplicits {
       head.read(indices.head.values.head, bytes) :: tail.value.read(indices.tail, bytes)
     }
 
-  implicit def consOneofProductReader[H <: Coproduct, T <: HList, IT <: HList](
+  implicit def hconsCoproductOneofProductReader[H <: Coproduct, T <: HList, IT <: HList](
       implicit
       head: PBOneofFieldReader[H],
       tail: Lazy[PBProductReader[T, IT]]): PBProductReader[Option[H] :: T, FieldIndex :: IT] =
     PBProductReader.instance { (indices: FieldIndex :: IT, bytes: Array[Byte]) =>
       head.read(indices.head.values, bytes) :: tail.value.read(indices.tail, bytes)
+    }
+
+  // read an Either[A, B] by treating it as a Coproduct (Left[A, B] :+: Right[A, B] :+: CNil)
+  implicit def hconsEitherOneofProductReader[A, B, H <: Coproduct, T <: HList, IT <: HList](
+      implicit
+      gen: Generic.Aux[Either[A, B], H],
+      productReader: PBProductReader[Option[H] :: T, FieldIndex :: IT]): PBProductReader[
+    Option[Either[A, B]] :: T,
+    FieldIndex :: IT] =
+    PBProductReader.instance { (indices: FieldIndex :: IT, bytes: Array[Byte]) =>
+      val result = productReader.read(indices, bytes)
+      result.head.map(gen.from) :: result.tail
     }
 
 }

--- a/src/main/scala/pbdirect/PBScalarValueReader.scala
+++ b/src/main/scala/pbdirect/PBScalarValueReader.scala
@@ -1,6 +1,7 @@
 package pbdirect
 
 import cats.Functor
+import cats.syntax.functor._
 import com.google.protobuf.CodedInputStream
 import shapeless._
 import enumeratum.values.{IntEnum, IntEnumEntry}
@@ -155,6 +156,14 @@ trait PBScalarValueReaderImplicits extends PBScalarValueReaderImplicits_1 {
       }
     }
   }
+
+  implicit def leftReader[A, B](
+      implicit reader: PBScalarValueReader[A]): PBScalarValueReader[Left[A, B]] =
+    reader.map(Left(_))
+
+  implicit def rightReader[A, B](
+      implicit reader: PBScalarValueReader[B]): PBScalarValueReader[Right[A, B]] =
+    reader.map(Right(_))
 
 }
 

--- a/src/main/scala/pbdirect/PBScalarValueWriter.scala
+++ b/src/main/scala/pbdirect/PBScalarValueWriter.scala
@@ -207,11 +207,11 @@ trait PBScalarValueWriterImplicits extends LowPriorityPBScalarValueWriterImplici
 
   implicit def leftWriter[A, B](
       implicit writer: PBScalarValueWriter[A]): PBScalarValueWriter[Left[A, B]] =
-    writer.contramap(_.value)
+    writer.contramap(_.a)
 
   implicit def rightWriter[A, B](
       implicit writer: PBScalarValueWriter[B]): PBScalarValueWriter[Right[A, B]] =
-    writer.contramap(_.value)
+    writer.contramap(_.b)
 
 }
 

--- a/src/main/scala/pbdirect/PBScalarValueWriter.scala
+++ b/src/main/scala/pbdirect/PBScalarValueWriter.scala
@@ -3,6 +3,7 @@ package pbdirect
 import java.io.ByteArrayOutputStream
 
 import cats.Contravariant
+import cats.syntax.contravariant._
 import com.google.protobuf.CodedOutputStream
 import com.google.protobuf.WireFormat._
 import enumeratum.values.IntEnumEntry
@@ -203,6 +204,14 @@ trait PBScalarValueWriterImplicits extends LowPriorityPBScalarValueWriterImplici
           writer.writeWithoutTag(f(b), out)
       }
   }
+
+  implicit def leftWriter[A, B](
+      implicit writer: PBScalarValueWriter[A]): PBScalarValueWriter[Left[A, B]] =
+    writer.contramap(_.value)
+
+  implicit def rightWriter[A, B](
+      implicit writer: PBScalarValueWriter[B]): PBScalarValueWriter[Right[A, B]] =
+    writer.contramap(_.value)
 
 }
 

--- a/src/test/scala/pbdirect/PBMessageReaderSpec.scala
+++ b/src/test/scala/pbdirect/PBMessageReaderSpec.scala
@@ -108,5 +108,17 @@ class PBMessageReaderSpec extends AnyWordSpecLike with Matchers {
       val bytes = Array[Byte](26, 4, 8, 5, 42, 0)
       bytes.pbTo[WrapperMessage] shouldBe WrapperMessage(CoproductMessage(5, Some("".inject[Cop])))
     }
+    case class EitherMessage(
+        @pbIndex(1) a: Int,
+        @pbIndex(3, 5) either: Option[Either[String, Int]]
+    )
+    "read a properly annotated message with an Either field (left)" in {
+      val bytes = Array[Byte](8, 5, 26, 5, 72, 101, 108, 108, 111)
+      bytes.pbTo[EitherMessage] shouldBe EitherMessage(5, Some(Left("Hello")))
+    }
+    "write a properly annotated message with an Either field (right)" in {
+      val bytes = Array[Byte](8, 5, 40, 8)
+      bytes.pbTo[EitherMessage] shouldBe EitherMessage(5, Some(Right(8)))
+    }
   }
 }

--- a/src/test/scala/pbdirect/PBMessageWriterSpec.scala
+++ b/src/test/scala/pbdirect/PBMessageWriterSpec.scala
@@ -121,5 +121,17 @@ class PBMessageWriterSpec extends AnyWordSpecLike with Matchers {
       val message = CoproductMessage(5, Some("".inject[Cop]))
       message.toPB shouldBe Array[Byte](8, 5, 42, 0)
     }
+    case class EitherMessage(
+        @pbIndex(1) a: Int,
+        @pbIndex(3, 5) either: Option[Either[String, Int]]
+    )
+    "write a properly annotated message with an Either field (left)" in {
+      val message = EitherMessage(5, Some(Left("Hello")))
+      message.toPB shouldBe Array[Byte](8, 5, 26, 5, 72, 101, 108, 108, 111)
+    }
+    "write a properly annotated message with an Either field (right)" in {
+      val message = EitherMessage(5, Some(Right(8)))
+      message.toPB shouldBe Array[Byte](8, 5, 40, 8)
+    }
   }
 }

--- a/src/test/scala/pbdirect/RoundTripSpec.scala
+++ b/src/test/scala/pbdirect/RoundTripSpec.scala
@@ -59,7 +59,8 @@ object RoundTripSpec {
       @pbIndex(10) string: String,
       @pbIndex(15) emptyMessage: EmptyMessage,
       @pbIndex(20) nestedMessage: MessageOne,
-      @pbIndex(21, 22, 23) coproduct: Option[Int :+: String :+: MessageOne :+: CNil]
+      @pbIndex(21, 22, 23) coproduct: Option[Int :+: String :+: MessageOne :+: CNil],
+      @pbIndex(24, 25) either: Option[Either[Int, String]]
   )
 
   case class MessageThree(
@@ -157,6 +158,14 @@ trait PBEquivalenceImplicits_1 extends PBEquivalenceImplicits_2 {
     option("bytesOption", Array.empty[Byte])
   implicit val enumOption: PBEquivalence[Option[Status]] =
     option("enumOption", Status.withValue(0))
+
+  implicit def either[A, B](
+      implicit aEquiv: PBEquivalence[A],
+      bEquiv: PBEquivalence[B]): PBEquivalence[Either[A, B]] = instance("either") {
+    case (Left(a1), Left(a2))   => aEquiv.equiv(a1, a2)
+    case (Right(b1), Right(b2)) => bEquiv.equiv(b1, b2)
+    case _                      => false
+  }
 
   object fieldEquivalence extends Poly2 {
     implicit def defaultCase[A](implicit equiv: PBEquivalence[A]): Case.Aux[A, A, Boolean] =


### PR DESCRIPTION
`Either[A, B]` is isomorphic to `A :+: B :+: CNil`, which we already know how to handle, so we reuse the existing implementation.