### PR TITLE
Support signed/unsigned/fixed-width integers

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,58 @@ case class UnpackedMessage(
 )
 ```
 
+## Fancy integer types (signed/unsigned/fixed-width)
+
+You can tell pbdirect that an Int/Long field should be encoded in a special way
+by tagging its type with `Signed`, `Unsigned` or `Fixed`. For example:
+
+```scala
+import shapeless.tag.@@
+import pbdirect.{Signed, Unsigned, Fixed}
+
+case class IntsMessage(
+  normalInt            : Int,
+  signedInt            : Int @@ Signed,
+  unsignedInt          : Int @@ Unsigned,
+  fixedWidthInt        : Int @@ Fixed,
+  fixedSignedWidthInt  : Int @@ (Signed with Fixed),
+  normalLong           : Long,
+  signedLong           : Long @@ Signed,
+  unsignedLong         : Long @@ Unsigned,
+  fixedWidthLong       : Long @@ Fixed,
+  fixedSignedWidthLong : Long @@ (Signed with Fixed)
+)
+```
+
+would correspond to the following Protobuf definition:
+
+
+```protobuf
+message IntsMessage {
+  int32      normalInt              =   1;
+  sint32     signedInt              =   2;
+  uint32     unsignedInt            =   3;
+  fixed32    fixedWidthInt          =   4;
+  sfixed32   fixedSignedWidthInt    =   5;
+  int64      normalLong             =   6;
+  sint64     signedLong             =   7;
+  uint64     unsignedLong           =   8;
+  fixed64    fixedWidthLong         =   9;
+  sfixed64   fixedSignedWidthLong   =   10;
+}
+```
+
+You can also tag individual types inside coproducts, key and value types of maps
+and element types of lists:
+
+```scala
+case class AnotherIntsMessage(
+  @pbIndex(1, 2) signedIntOrNormalInt  : (Int @@ Signed) :+: Int :+: CNil,
+  @pbIndex(3)    signedIntFixedLongMap : Map[Int @@ Signed, Long @@ Fixed],
+  @pbIndex(4)    signedIntList         : List[Int @@ Signed]
+)
+```
+
 [comment]: # (Start Copyright)
 # Copyright
 

--- a/src/main/scala/pbdirect/IntegerTags.scala
+++ b/src/main/scala/pbdirect/IntegerTags.scala
@@ -1,0 +1,76 @@
+package pbdirect
+
+/**
+ * A modifier to signify that an integer field is encoded as a signed Protobuf type
+ * (sint32, sint64, sfixed32 or sfixed64).
+ *
+ * This modifier is used by attaching it to a field's type as a shapeless tag.
+ * e.g.
+ *
+ * {{{
+ * import shapeless.tag.@@
+ * import pbdirect.Signed
+ *
+ * case class MyMessage(
+ *   signedInt: Int @@ Signed,  // will be encoded as an sint32
+ *   signedLong: Long @@ Signed // will be encoded as an sint64
+ * )
+ * }}}
+ *
+ * It can also be combined with the [[Fixed]] tag, e.g.
+ *
+ * {{{
+ * case class MyMessage(
+ *   fixedSignedInt: Int @@ (Signed with Fixed),  // will be encoded as an sfixed32
+ *   fixedSignedLong: Long @@ (Signed with Fixed) // will be encoded as an sfixed64
+ * )
+ * }}}
+ */
+sealed trait Signed
+
+/**
+ * A modifier to signify that an integer field is encoded as an unsigned Protobuf type
+ * (uint32 or uint64).
+ *
+ * This modifier is used by attaching it to a field's type as a shapeless tag.
+ * e.g.
+ *
+ * {{{
+ * import shapeless.tag.@@
+ * import pbdirect.Unsigned
+ *
+ * case class MyMessage(
+ *   signedInt: Int @@ Unsigned,   // will be encoded as a uint32
+ *   signedLong: Long @@ Unsigned, // will be encoded as a uint64
+ * )
+ * }}}
+ */
+sealed trait Unsigned
+
+/**
+ * A modifier to signify that an integer field is encoded as a fixed-width Protobuf type
+ * (fixed32, fixed64, sfixed32 or sfixed64).
+ *
+ * This modifier is used by attaching it to a field's type as a shapeless tag.
+ * e.g.
+ *
+ * {{{
+ * import shapeless.tag.@@
+ * import pbdirect.Fixed
+ *
+ * case class MyMessage(
+ *   signedInt: Int @@ Fixed,   // will be encoded as a fixed32
+ *   signedLong: Long @@ Fixed, // will be encoded as a fixed64
+ * )
+ * }}}
+ *
+ * It can also be combined with the [[Signed]] tag, e.g.
+ *
+ * {{{
+ * case class MyMessage(
+ *   fixedSignedInt: Int @@ (Signed with Fixed),  // will be encoded as an sfixed32
+ *   fixedSignedLong: Long @@ (Signed with Fixed) // will be encoded as an sfixed64
+ * )
+ * }}}
+ */
+sealed trait Fixed

--- a/src/main/scala/pbdirect/PBScalarValueReader.scala
+++ b/src/main/scala/pbdirect/PBScalarValueReader.scala
@@ -68,35 +68,24 @@ trait PBScalarValueReaderImplicits extends PBScalarValueReaderImplicits_1 {
     override def read(input: CodedInputStream): Int = input.readInt32()
   }
 
-  implicit val unsignedIntReader: PBScalarValueReader[Int @@ Unsigned] =
-    new PBScalarValueReader[Int @@ Unsigned] {
-      override def defaultValue: Int @@ Unsigned = tag[Unsigned](0)
-      override def canBePacked: Boolean          = true
-      override def read(input: CodedInputStream): Int @@ Unsigned =
-        tag[Unsigned](input.readUInt32())
+  def taggedIntReader[T](readInt: CodedInputStream => Int): PBScalarValueReader[Int @@ T] =
+    new PBScalarValueReader[Int @@ T] {
+      override def defaultValue: Int @@ T                  = tag[T](0)
+      override def canBePacked: Boolean                    = true
+      override def read(input: CodedInputStream): Int @@ T = tag[T](readInt(input))
     }
+
+  implicit val unsignedIntReader: PBScalarValueReader[Int @@ Unsigned] =
+    taggedIntReader[Unsigned](_.readUInt32())
 
   implicit val signedIntReader: PBScalarValueReader[Int @@ Signed] =
-    new PBScalarValueReader[Int @@ Signed] {
-      override def defaultValue: Int @@ Signed                  = tag[Signed](0)
-      override def canBePacked: Boolean                         = true
-      override def read(input: CodedInputStream): Int @@ Signed = tag[Signed](input.readSInt32())
-    }
+    taggedIntReader[Signed](_.readSInt32())
 
   implicit val fixedIntReader: PBScalarValueReader[Int @@ Fixed] =
-    new PBScalarValueReader[Int @@ Fixed] {
-      override def defaultValue: Int @@ Fixed                  = tag[Fixed](0)
-      override def canBePacked: Boolean                        = true
-      override def read(input: CodedInputStream): Int @@ Fixed = tag[Fixed](input.readFixed32())
-    }
+    taggedIntReader[Fixed](_.readFixed32())
 
   implicit val fixedSignedIntReader: PBScalarValueReader[Int @@ (Signed with Fixed)] =
-    new PBScalarValueReader[Int @@ (Signed with Fixed)] {
-      override def defaultValue: Int @@ (Signed with Fixed) = tag[(Signed with Fixed)](0)
-      override def canBePacked: Boolean                     = true
-      override def read(input: CodedInputStream): Int @@ (Signed with Fixed) =
-        tag[(Signed with Fixed)](input.readSFixed32())
-    }
+    taggedIntReader[Signed with Fixed](_.readSFixed32())
 
   // Stored as variants, but larger in memory: https://groups.google.com/forum/#!topic/protobuf/Er39mNGnRWU
   implicit val byteReader: PBScalarValueReader[Byte] = untaggedIntReader.map(_.toByte)
@@ -110,35 +99,24 @@ trait PBScalarValueReaderImplicits extends PBScalarValueReaderImplicits_1 {
     override def read(input: CodedInputStream): Long = input.readInt64()
   }
 
-  implicit val unsignedLongReader: PBScalarValueReader[Long @@ Unsigned] =
-    new PBScalarValueReader[Long @@ Unsigned] {
-      override def defaultValue: Long @@ Unsigned = tag[Unsigned](0L)
-      override def canBePacked: Boolean           = true
-      override def read(input: CodedInputStream): Long @@ Unsigned =
-        tag[Unsigned](input.readUInt64())
+  def taggedLongReader[T](readLong: CodedInputStream => Long): PBScalarValueReader[Long @@ T] =
+    new PBScalarValueReader[Long @@ T] {
+      override def defaultValue: Long @@ T                  = tag[T](0L)
+      override def canBePacked: Boolean                     = true
+      override def read(input: CodedInputStream): Long @@ T = tag[T](readLong(input))
     }
+
+  implicit val unsignedLongReader: PBScalarValueReader[Long @@ Unsigned] =
+    taggedLongReader[Unsigned](_.readUInt64())
 
   implicit val signedLongReader: PBScalarValueReader[Long @@ Signed] =
-    new PBScalarValueReader[Long @@ Signed] {
-      override def defaultValue: Long @@ Signed                  = tag[Signed](0L)
-      override def canBePacked: Boolean                          = true
-      override def read(input: CodedInputStream): Long @@ Signed = tag[Signed](input.readSInt64())
-    }
+    taggedLongReader[Signed](_.readSInt64())
 
   implicit val fixedLongReader: PBScalarValueReader[Long @@ Fixed] =
-    new PBScalarValueReader[Long @@ Fixed] {
-      override def defaultValue: Long @@ Fixed                  = tag[Fixed](0L)
-      override def canBePacked: Boolean                         = true
-      override def read(input: CodedInputStream): Long @@ Fixed = tag[Fixed](input.readFixed64())
-    }
+    taggedLongReader[Fixed](_.readFixed64())
 
   implicit val fixedSignedLongReader: PBScalarValueReader[Long @@ (Signed with Fixed)] =
-    new PBScalarValueReader[Long @@ (Signed with Fixed)] {
-      override def defaultValue: Long @@ (Signed with Fixed) = tag[(Signed with Fixed)](0L)
-      override def canBePacked: Boolean                      = true
-      override def read(input: CodedInputStream): Long @@ (Signed with Fixed) =
-        tag[(Signed with Fixed)](input.readSFixed64())
-    }
+    taggedLongReader[Signed with Fixed](_.readSFixed64())
 
   implicit val floatReader: PBScalarValueReader[Float] = new PBScalarValueReader[Float] {
     override def defaultValue: Float                  = 0.0F

--- a/src/test/resources/proto/ProtocComparisonSpec.proto
+++ b/src/test/resources/proto/ProtocComparisonSpec.proto
@@ -28,4 +28,5 @@ message MessageThree {
   MessageOne messageOneOption = 10;
   MessageTwo messageTwo = 11;
   map<int32, MessageTwo> intMessageTwoMap = 12;
+  map<sint32, fixed64> signedIntFixedLongMap = 13;
 }

--- a/src/test/scala/pbdirect/PBFieldReaderSpec.scala
+++ b/src/test/scala/pbdirect/PBFieldReaderSpec.scala
@@ -3,6 +3,7 @@ package pbdirect
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import enumeratum.values._
+import shapeless.tag.@@
 
 class PBFieldReaderSpec extends AnyWordSpecLike with Matchers {
 
@@ -23,9 +24,45 @@ class PBFieldReaderSpec extends AnyWordSpecLike with Matchers {
       val bytes = Array[Byte](8, 5)
       PBFieldReader[Int].read(1, bytes) shouldBe 5
     }
+    "read an unsigned Int from Protobuf" in {
+      val bytes = Array[Byte](8, 5)
+      PBFieldReader[Int @@ Unsigned].read(1, bytes) shouldBe 5
+    }
+    "read a signed Int from Protobuf" in {
+      val bytes = Array[Byte](8, 9)
+      PBFieldReader[Int @@ Signed].read(1, bytes) shouldBe -5
+    }
+    "read a fixed-width Int from Protobuf" in {
+      val bytes = Array[Byte](13, 5, 0, 0, 0)
+      PBFieldReader[Int @@ Fixed].read(1, bytes) shouldBe 5
+    }
+    "read a signed fixed-width Int from Protobuf" in {
+      // sfixed32 is encoded exactly the same way as fixed32,
+      // so the bytes are the same as in the test above
+      val bytes = Array[Byte](13, 5, 0, 0, 0)
+      PBFieldReader[Int @@ (Signed with Fixed)].read(1, bytes) shouldBe 5
+    }
     "read a Long from Protobuf" in {
       val bytes = Array[Byte](8, -128, -128, -128, -128, 8)
       PBFieldReader[Long].read(1, bytes) shouldBe Int.MaxValue.toLong + 1
+    }
+    "read an unsigned Long from Protobuf" in {
+      val bytes = Array[Byte](8, -128, -128, -128, -128, 8)
+      PBFieldReader[Long @@ Unsigned].read(1, bytes) shouldBe Int.MaxValue.toLong + 1
+    }
+    "read a signed Long from Protobuf" in {
+      val bytes = Array[Byte](8, -128, -128, -128, -128, 16)
+      PBFieldReader[Long @@ Signed].read(1, bytes) shouldBe Int.MaxValue.toLong + 1
+    }
+    "read a fixed-width Long from Protobuf" in {
+      val bytes = Array[Byte](9, 0, 0, 0, -128, 0, 0, 0, 0)
+      PBFieldReader[Long @@ Fixed].read(1, bytes) shouldBe Int.MaxValue.toLong + 1
+    }
+    "read a signed fixed-width Long from Protobuf" in {
+      // sfixed64 is encoded exactly the same way as fixed64,
+      // so the bytes are the same as in the test above
+      val bytes = Array[Byte](9, 0, 0, 0, -128, 0, 0, 0, 0)
+      PBFieldReader[Long @@ (Signed with Fixed)].read(1, bytes) shouldBe Int.MaxValue.toLong + 1
     }
     "read a Float from Protobuf" in {
       val bytes = Array[Byte](13, -51, -52, 76, 62)

--- a/src/test/scala/pbdirect/PBMessageReaderSpec.scala
+++ b/src/test/scala/pbdirect/PBMessageReaderSpec.scala
@@ -4,6 +4,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import shapeless._
 import shapeless.syntax.inject._
+import shapeless.tag.@@
 
 class PBMessageReaderSpec extends AnyWordSpecLike with Matchers {
 
@@ -119,6 +120,11 @@ class PBMessageReaderSpec extends AnyWordSpecLike with Matchers {
     "write a properly annotated message with an Either field (right)" in {
       val bytes = Array[Byte](8, 5, 40, 8)
       bytes.pbTo[EitherMessage] shouldBe EitherMessage(5, Some(Right(8)))
+    }
+    "read a message with a signed int field" in {
+      case class SignedIntMessage(a: Int @@ Signed, b: String)
+      val bytes = Array[Byte](8, 9, 18, 5, 72, 101, 108, 108, 111)
+      bytes.pbTo[SignedIntMessage] shouldBe SignedIntMessage(tag[Signed](-5), "Hello")
     }
   }
 }


### PR DESCRIPTION
Support signed/unsigned/fixed-width integers via tagged types

* Define `Signed`, `Unsigned`, `Fixed` tags
* Add PBScalarValueReader/Writers for tagged Int/Long types
* Write unit tests and extend the property-based tests
* Document the feature in the README

Initially I planned to implement this using annotations on fields, e.g. `@pbFixed`, but it didn't really work. e.g. the following two examples would be impossible to encode in Scala using field annotations:

```protobuf
message Foo {
  map<sint32, int> mapWithSignedKeys = 1;
}
```

```protobuf
message Foo {
  oneof signedOrNormalInt {
    sint32 signed = 1;
    int32 normal = 2;
  }
}
```