### PR TITLE
Cross build for 2.13 and drop 2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
   - openjdk8
 scala:
   - 2.12.10
-  - 2.11.12
+  - 2.13.1
 script:
   - sbt ++$TRAVIS_SCALA_VERSION orgScriptCI
 after_success:

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -20,8 +20,8 @@ object ProjectPlugin extends AutoPlugin {
     lazy val V = new {
       val cats: String                = "2.0.0"
       val protobuf: String            = "3.11.1"
-      val scala211: String            = "2.11.12"
       val scala212: String            = "2.12.10"
+      val scala213: String            = "2.13.1"
       val shapeless: String           = "2.3.3"
       val enumeratum: String          = "1.5.15"
       val scalaTest: String           = "3.1.0"
@@ -44,7 +44,8 @@ object ProjectPlugin extends AutoPlugin {
   }
 
   override def projectSettings: Seq[Def.Setting[_]] =
-    sharedReleaseProcess ++ warnUnusedImport ++ Seq(
+    // TODO re-add `warnUnusedImport` after upgrading sbt-org-policies
+    sharedReleaseProcess ++ Seq(
       orgProjectName := "pbdirect",
       orgGithubSetting := GitHubSettings(
         organization = "47deg",
@@ -60,7 +61,7 @@ object ProjectPlugin extends AutoPlugin {
       headerMappings := headerMappings.value + (HeaderFileType.scala -> HeaderCommentStyle.CppStyleLineComment),
       startYear := Some(2019),
       scalaVersion := V.scala212,
-      crossScalaVersions := Seq(scalaVersion.value, V.scala211),
+      crossScalaVersions := Seq(scalaVersion.value, V.scala213),
       libraryDependencies ++= Seq(
         "com.chuusai"                %% "shapeless"                 % V.shapeless,
         "org.typelevel"              %% "cats-core"                 % V.cats,

--- a/src/main/scala/pbdirect/Enum.scala
+++ b/src/main/scala/pbdirect/Enum.scala
@@ -14,7 +14,8 @@ object Enum {
   object Values {
     implicit def values[A, Repr <: Coproduct](
         implicit gen: Generic.Aux[A, Repr],
-        v: Aux[A, Repr]): Values[A] =
+        v: Aux[A, Repr]
+    ): Values[A] =
       new Values[A] { def apply = v.values }
 
     trait Aux[A, Repr] {
@@ -25,7 +26,8 @@ object Enum {
       implicit def cnilAux[E]: Aux[E, CNil] = new Aux[E, CNil] { def values = Nil }
       implicit def cconsAux[E, V <: E, R <: Coproduct](
           implicit l: Witness.Aux[V],
-          r: Aux[E, R]): Aux[E, V :+: R] =
+          r: Aux[E, R]
+      ): Aux[E, V :+: R] =
         new Aux[E, V :+: R] { def values = l.value :: r.values }
     }
   }

--- a/src/main/scala/pbdirect/PBFieldReader.scala
+++ b/src/main/scala/pbdirect/PBFieldReader.scala
@@ -13,7 +13,8 @@ trait PBFieldReaderImplicits {
   }
 
   implicit def repeatedFieldReader[A](
-      implicit reader: PBScalarValueReader[A]): PBFieldReader[List[A]] =
+      implicit reader: PBScalarValueReader[A]
+  ): PBFieldReader[List[A]] =
     instance { (index: Int, bytes: Array[Byte]) =>
       val input       = CodedInputStream.newInstance(bytes)
       var done        = false
@@ -52,19 +53,22 @@ trait PBFieldReaderImplicits {
     }
 
   implicit def optionalFieldReader[A](
-      implicit reader: PBFieldReader[List[A]]): PBFieldReader[Option[A]] =
+      implicit reader: PBFieldReader[List[A]]
+  ): PBFieldReader[Option[A]] =
     instance { (index: Int, bytes: Array[Byte]) =>
       reader.read(index, bytes).lastOption
     }
 
   implicit def mapFieldReader[K, V](
-      implicit reader: PBFieldReader[List[(K, V)]]): PBFieldReader[Map[K, V]] =
+      implicit reader: PBFieldReader[List[(K, V)]]
+  ): PBFieldReader[Map[K, V]] =
     instance { (index: Int, bytes: Array[Byte]) =>
       reader.read(index, bytes).toMap
     }
 
   implicit def collectionMapFieldReader[K, V](
-      implicit reader: PBFieldReader[List[(K, V)]]): PBFieldReader[collection.Map[K, V]] =
+      implicit reader: PBFieldReader[List[(K, V)]]
+  ): PBFieldReader[collection.Map[K, V]] =
     instance { (index: Int, bytes: Array[Byte]) =>
       reader.read(index, bytes).toMap
     }

--- a/src/main/scala/pbdirect/PBFieldWriter.scala
+++ b/src/main/scala/pbdirect/PBFieldWriter.scala
@@ -17,7 +17,8 @@ trait PBFieldWriterImplicits {
           index: Int,
           value: A,
           out: CodedOutputStream,
-          flags: PBFieldWriter.Flags): Unit =
+          flags: PBFieldWriter.Flags
+      ): Unit =
         f(index, value, out, flags)
     }
 
@@ -56,19 +57,22 @@ trait PBFieldWriterImplicits {
     }
 
   implicit def mapWriter[K, V](
-      implicit writer: PBFieldWriter[List[(K, V)]]): PBFieldWriter[Map[K, V]] =
+      implicit writer: PBFieldWriter[List[(K, V)]]
+  ): PBFieldWriter[Map[K, V]] =
     instance { (index: Int, value: Map[K, V], out: CodedOutputStream, flags: PBFieldWriter.Flags) =>
       writer.writeTo(index, value.toList, out, flags)
     }
 
   implicit def collectionMapWriter[K, V](
-      implicit writer: PBFieldWriter[List[(K, V)]]): PBFieldWriter[collection.Map[K, V]] =
+      implicit writer: PBFieldWriter[List[(K, V)]]
+  ): PBFieldWriter[collection.Map[K, V]] =
     instance {
       (
           index: Int,
           value: collection.Map[K, V],
           out: CodedOutputStream,
-          flags: PBFieldWriter.Flags) =>
+          flags: PBFieldWriter.Flags
+      ) =>
         writer.writeTo(index, value.toList, out, flags)
     }
 

--- a/src/main/scala/pbdirect/PBFormat.scala
+++ b/src/main/scala/pbdirect/PBFormat.scala
@@ -19,7 +19,8 @@ trait PBFormatImplicits {
 object PBFormat extends PBFormatImplicits {
   def apply[A](
       implicit reader: PBScalarValueReader[A],
-      writer: PBScalarValueWriter[A]): PBFormat[A] =
+      writer: PBScalarValueWriter[A]
+  ): PBFormat[A] =
     new PBFormat[A] {
       override def read(input: CodedInputStream): A = reader.read(input)
       override def wireType: Int                    = writer.wireType

--- a/src/main/scala/pbdirect/PBMessageReader.scala
+++ b/src/main/scala/pbdirect/PBMessageReader.scala
@@ -30,7 +30,8 @@ trait PBMessageReaderImplicits {
       annotations: Annotations.Aux[pbIndex, A, Anns],
       zwi: ZipWithIndex.Aux[Anns, ZWI],
       indices: Mapper.Aux[collectFieldIndices.type, ZWI, I],
-      reader: Lazy[PBProductReader[R, I]]): PBMessageReader[A] = instance { (bytes: Array[Byte]) =>
+      reader: Lazy[PBProductReader[R, I]]
+  ): PBMessageReader[A] = instance { (bytes: Array[Byte]) =>
     val fieldIndices = annotations.apply.zipWithIndex.map(collectFieldIndices)
     gen.from(reader.value.read(fieldIndices, bytes))
   }

--- a/src/main/scala/pbdirect/PBMessageWriter.scala
+++ b/src/main/scala/pbdirect/PBMessageWriter.scala
@@ -46,14 +46,16 @@ trait PBMessageWriterImplicits {
       UA <: HList,
       ZWI <: HList,
       ZWFI <: HList,
-      ZWM <: HList](
+      ZWM <: HList
+  ](
       implicit gen: Generic.Aux[A, R],
       indexAnns: Annotations.Aux[pbIndex, A, IA],
       unpackedAnns: Annotations.Aux[pbUnpacked, A, UA],
       zwi: ZipWithIndex.Aux[R, ZWI],
       zwfi: ZipWith.Aux[IA, ZWI, zipWithFieldIndex.type, ZWFI],
       zwm: ZipWith.Aux[ZWFI, UA, zipWithModifiers.type, ZWM],
-      writer: Lazy[PBProductWriter[ZWM]]): PBMessageWriter[A] =
+      writer: Lazy[PBProductWriter[ZWM]]
+  ): PBMessageWriter[A] =
     instance { (value: A, out: CodedOutputStream) =>
       val fields                     = gen.to(value)
       val fieldsWithIndices          = fields.zipWithIndex

--- a/src/main/scala/pbdirect/PBOneofFieldReader.scala
+++ b/src/main/scala/pbdirect/PBOneofFieldReader.scala
@@ -17,7 +17,8 @@ trait PBOneofFieldReaderImplicits {
   implicit def cconsReader[H, T <: Coproduct](
       implicit
       headReader: PBFieldReader[Option[H]],
-      tailReader: Lazy[PBOneofFieldReader[T]]): PBOneofFieldReader[H :+: T] =
+      tailReader: Lazy[PBOneofFieldReader[T]]
+  ): PBOneofFieldReader[H :+: T] =
     instance { (indices: List[Int], bytes: Array[Byte]) =>
       headReader
         .read(indices.head, bytes)

--- a/src/main/scala/pbdirect/PBOneofFieldWriter.scala
+++ b/src/main/scala/pbdirect/PBOneofFieldWriter.scala
@@ -8,29 +8,33 @@ trait PBOneofFieldWriter[A <: Coproduct] {
       indices: List[Int],
       value: A,
       out: CodedOutputStream,
-      flags: PBFieldWriter.Flags): Unit
+      flags: PBFieldWriter.Flags
+  ): Unit
 }
 
 trait PBOneofFieldWriterImplicits {
 
   def instance[A <: Coproduct](
-      f: (List[Int], A, CodedOutputStream, PBFieldWriter.Flags) => Unit): PBOneofFieldWriter[A] =
+      f: (List[Int], A, CodedOutputStream, PBFieldWriter.Flags) => Unit
+  ): PBOneofFieldWriter[A] =
     new PBOneofFieldWriter[A] {
       override def writeTo(
           indices: List[Int],
           value: A,
           out: CodedOutputStream,
-          flags: PBFieldWriter.Flags): Unit =
+          flags: PBFieldWriter.Flags
+      ): Unit =
         f(indices, value, out, flags)
     }
 
-  implicit val cnilWriter: PBOneofFieldWriter[CNil] = instance(
-    (_, _, _, _) => throw new IllegalStateException("Cannot write CNil"))
+  implicit val cnilWriter: PBOneofFieldWriter[CNil] =
+    instance((_, _, _, _) => throw new IllegalStateException("Cannot write CNil"))
 
   implicit def cconsWriter[H, T <: Coproduct](
       implicit
       headWriter: PBFieldWriter[H],
-      tailWriter: Lazy[PBOneofFieldWriter[T]]): PBOneofFieldWriter[H :+: T] =
+      tailWriter: Lazy[PBOneofFieldWriter[T]]
+  ): PBOneofFieldWriter[H :+: T] =
     instance {
       (indices: List[Int], value: H :+: T, out: CodedOutputStream, flags: PBFieldWriter.Flags) =>
         value match {

--- a/src/main/scala/pbdirect/PBProductReader.scala
+++ b/src/main/scala/pbdirect/PBProductReader.scala
@@ -21,7 +21,8 @@ trait PBProductReaderImplicits {
   implicit def hconsProductReader[H, T <: HList, IT <: HList](
       implicit
       head: PBFieldReader[H],
-      tail: Lazy[PBProductReader[T, IT]]): PBProductReader[H :: T, FieldIndex :: IT] =
+      tail: Lazy[PBProductReader[T, IT]]
+  ): PBProductReader[H :: T, FieldIndex :: IT] =
     PBProductReader.instance { (indices: FieldIndex :: IT, bytes: Array[Byte]) =>
       head.read(indices.head.values.head, bytes) :: tail.value.read(indices.tail, bytes)
     }
@@ -29,7 +30,8 @@ trait PBProductReaderImplicits {
   implicit def hconsCoproductOneofProductReader[H <: Coproduct, T <: HList, IT <: HList](
       implicit
       head: PBOneofFieldReader[H],
-      tail: Lazy[PBProductReader[T, IT]]): PBProductReader[Option[H] :: T, FieldIndex :: IT] =
+      tail: Lazy[PBProductReader[T, IT]]
+  ): PBProductReader[Option[H] :: T, FieldIndex :: IT] =
     PBProductReader.instance { (indices: FieldIndex :: IT, bytes: Array[Byte]) =>
       head.read(indices.head.values, bytes) :: tail.value.read(indices.tail, bytes)
     }
@@ -38,9 +40,8 @@ trait PBProductReaderImplicits {
   implicit def hconsEitherOneofProductReader[A, B, H <: Coproduct, T <: HList, IT <: HList](
       implicit
       gen: Generic.Aux[Either[A, B], H],
-      productReader: PBProductReader[Option[H] :: T, FieldIndex :: IT]): PBProductReader[
-    Option[Either[A, B]] :: T,
-    FieldIndex :: IT] =
+      productReader: PBProductReader[Option[H] :: T, FieldIndex :: IT]
+  ): PBProductReader[Option[Either[A, B]] :: T, FieldIndex :: IT] =
     PBProductReader.instance { (indices: FieldIndex :: IT, bytes: Array[Byte]) =>
       val result = productReader.read(indices, bytes)
       result.head.map(gen.from) :: result.tail

--- a/src/main/scala/pbdirect/PBProductWriter.scala
+++ b/src/main/scala/pbdirect/PBProductWriter.scala
@@ -20,7 +20,8 @@ trait PBProductWriterImplicits {
 
   implicit def hconsWriter[H, T <: HList](
       implicit head: PBFieldWriter[H],
-      tail: Lazy[PBProductWriter[T]]): PBProductWriter[(FieldIndex, H, FieldModifiers) :: T] =
+      tail: Lazy[PBProductWriter[T]]
+  ): PBProductWriter[(FieldIndex, H, FieldModifiers) :: T] =
     instance { (indexedValues: (FieldIndex, H, FieldModifiers) :: T, out: CodedOutputStream) =>
       val headIndex     = indexedValues.head._1.values.head
       val headValue     = indexedValues.head._2
@@ -32,8 +33,8 @@ trait PBProductWriterImplicits {
 
   implicit def hconsCoproductOneofWriter[H <: Coproduct, T <: HList](
       implicit head: PBOneofFieldWriter[H],
-      tail: Lazy[PBProductWriter[T]]): PBProductWriter[
-    (FieldIndex, Option[H], FieldModifiers) :: T] =
+      tail: Lazy[PBProductWriter[T]]
+  ): PBProductWriter[(FieldIndex, Option[H], FieldModifiers) :: T] =
     instance {
       (indexedValues: (FieldIndex, Option[H], FieldModifiers) :: T, out: CodedOutputStream) =>
         indexedValues.head match {
@@ -54,7 +55,8 @@ trait PBProductWriterImplicits {
     instance {
       (
           indexedValues: (FieldIndex, Option[Either[A, B]], FieldModifiers) :: T,
-          out: CodedOutputStream) =>
+          out: CodedOutputStream
+      ) =>
         val headEitherAsCoproduct: Option[H] = indexedValues.head._2.map(gen.to)
         val head                             = indexedValues.head.copy(_2 = headEitherAsCoproduct)
         productWriter.writeTo(head :: indexedValues.tail, out)

--- a/src/main/scala/pbdirect/PBScalarValueReader.scala
+++ b/src/main/scala/pbdirect/PBScalarValueReader.scala
@@ -30,7 +30,8 @@ trait PBScalarValueReader[A] {
 trait PBScalarValueReaderImplicits_1 {
 
   implicit def embeddedMessageReader[A](
-      implicit reader: PBMessageReader[A]): PBScalarValueReader[A] =
+      implicit reader: PBMessageReader[A]
+  ): PBScalarValueReader[A] =
     new PBScalarValueReader[A] {
       // To construct a default instance of the message
       // we decode a byte array of length zero,
@@ -119,7 +120,7 @@ trait PBScalarValueReaderImplicits extends PBScalarValueReaderImplicits_1 {
     taggedLongReader[Signed with Fixed](_.readSFixed64())
 
   implicit val floatReader: PBScalarValueReader[Float] = new PBScalarValueReader[Float] {
-    override def defaultValue: Float                  = 0.0F
+    override def defaultValue: Float                  = 0.0f
     override def canBePacked: Boolean                 = true
     override def read(input: CodedInputStream): Float = input.readFloat()
   }
@@ -147,7 +148,8 @@ trait PBScalarValueReaderImplicits extends PBScalarValueReaderImplicits_1 {
       implicit
       values: Enum.Values[A],
       ordering: Ordering[A],
-      reader: PBScalarValueReader[Int]): PBScalarValueReader[A] =
+      reader: PBScalarValueReader[Int]
+  ): PBScalarValueReader[A] =
     new PBScalarValueReader[A] {
       val defaultValue: A                  = Enum.fromInt[A](0)
       def canBePacked: Boolean             = true
@@ -157,7 +159,8 @@ trait PBScalarValueReaderImplicits extends PBScalarValueReaderImplicits_1 {
   implicit def enumerationReader[E <: Enumeration](
       implicit
       reader: PBScalarValueReader[Int],
-      gen: Generic.Aux[E, HNil]): PBScalarValueReader[E#Value] = {
+      gen: Generic.Aux[E, HNil]
+  ): PBScalarValueReader[E#Value] = {
     val enum = gen.from(HNil)
     new PBScalarValueReader[E#Value] {
       val defaultValue: E#Value                  = enum(0)
@@ -169,7 +172,8 @@ trait PBScalarValueReaderImplicits extends PBScalarValueReaderImplicits_1 {
   implicit def enumeratumIntEnumEntryReader[E <: IntEnumEntry](
       implicit
       reader: PBScalarValueReader[Int],
-      enum: IntEnum[E]): PBScalarValueReader[E] =
+      enum: IntEnum[E]
+  ): PBScalarValueReader[E] =
     new PBScalarValueReader[E] {
       val defaultValue: E                  = enum.withValue(0)
       def canBePacked: Boolean             = true
@@ -178,7 +182,8 @@ trait PBScalarValueReaderImplicits extends PBScalarValueReaderImplicits_1 {
 
   implicit def keyValuePairReader[K, V](
       implicit keyReader: PBScalarValueReader[K],
-      valueReader: PBScalarValueReader[V]): PBScalarValueReader[(K, V)] = {
+      valueReader: PBScalarValueReader[V]
+  ): PBScalarValueReader[(K, V)] = {
     val defaultKey   = keyReader.defaultValue
     val defaultValue = valueReader.defaultValue
     val defaultPair  = (defaultKey, defaultValue)
@@ -198,11 +203,13 @@ trait PBScalarValueReaderImplicits extends PBScalarValueReaderImplicits_1 {
   }
 
   implicit def leftReader[A, B](
-      implicit reader: PBScalarValueReader[A]): PBScalarValueReader[Left[A, B]] =
+      implicit reader: PBScalarValueReader[A]
+  ): PBScalarValueReader[Left[A, B]] =
     reader.map(Left(_))
 
   implicit def rightReader[A, B](
-      implicit reader: PBScalarValueReader[B]): PBScalarValueReader[Right[A, B]] =
+      implicit reader: PBScalarValueReader[B]
+  ): PBScalarValueReader[Right[A, B]] =
     reader.map(Right(_))
 
 }

--- a/src/main/scala/pbdirect/PBScalarValueWriter.scala
+++ b/src/main/scala/pbdirect/PBScalarValueWriter.scala
@@ -62,7 +62,8 @@ trait PBScalarValueWriter[A] {
 trait LowPriorityPBScalarValueWriterImplicits {
 
   implicit def embeddedMessageWriter[A](
-      implicit messageWriter: PBMessageWriter[A]): PBScalarValueWriter[A] =
+      implicit messageWriter: PBMessageWriter[A]
+  ): PBScalarValueWriter[A] =
     new PBScalarValueWriter[A] {
       override def wireType: Int                  = WIRETYPE_LENGTH_DELIMITED
       override def isDefault(message: A): Boolean = false
@@ -135,7 +136,8 @@ trait PBScalarValueWriterImplicits extends LowPriorityPBScalarValueWriterImplici
       override def isDefault(value: Int @@ (Signed with Fixed)): Boolean = value == 0
       override def writeWithoutTag(
           value: Int @@ (Signed with Fixed),
-          out: CodedOutputStream): Unit =
+          out: CodedOutputStream
+      ): Unit =
         out.writeSFixed32NoTag(value)
     }
 
@@ -183,14 +185,15 @@ trait PBScalarValueWriterImplicits extends LowPriorityPBScalarValueWriterImplici
       override def isDefault(value: Long @@ (Signed with Fixed)): Boolean = value == 0L
       override def writeWithoutTag(
           value: Long @@ (Signed with Fixed),
-          out: CodedOutputStream): Unit =
+          out: CodedOutputStream
+      ): Unit =
         out.writeSFixed64NoTag(value)
     }
 
   implicit val floatWriter: PBScalarValueWriter[Float] =
     new PBScalarValueWriter[Float] {
       override def wireType: Int                    = WIRETYPE_FIXED32
-      override def isDefault(value: Float): Boolean = value == 0.0F
+      override def isDefault(value: Float): Boolean = value == 0.0f
       override def writeWithoutTag(value: Float, out: CodedOutputStream): Unit =
         out.writeFloatNoTag(value)
     }
@@ -221,7 +224,8 @@ trait PBScalarValueWriterImplicits extends LowPriorityPBScalarValueWriterImplici
 
   implicit def keyValuePairWriter[K, V](
       implicit keyWriter: PBScalarValueWriter[K],
-      valueWriter: PBScalarValueWriter[V]): PBScalarValueWriter[(K, V)] =
+      valueWriter: PBScalarValueWriter[V]
+  ): PBScalarValueWriter[(K, V)] =
     new PBScalarValueWriter[(K, V)] {
       override def wireType: Int = WIRETYPE_LENGTH_DELIMITED
       override def isDefault(pair: (K, V)): Boolean =
@@ -240,7 +244,8 @@ trait PBScalarValueWriterImplicits extends LowPriorityPBScalarValueWriterImplici
 
   implicit def enumWriter[E](
       implicit values: Enum.Values[E],
-      ordering: Ordering[E]): PBScalarValueWriter[E] =
+      ordering: Ordering[E]
+  ): PBScalarValueWriter[E] =
     new PBScalarValueWriter[E] {
       override def wireType: Int                = WIRETYPE_VARINT
       override def isDefault(value: E): Boolean = Enum.toInt(value) == 0
@@ -265,12 +270,14 @@ trait PBScalarValueWriterImplicits extends LowPriorityPBScalarValueWriterImplici
     }
 
   implicit def leftWriter[A, B](
-      implicit writer: PBScalarValueWriter[A]): PBScalarValueWriter[Left[A, B]] =
-    writer.contramap(_.a)
+      implicit writer: PBScalarValueWriter[A]
+  ): PBScalarValueWriter[Left[A, B]] =
+    writer.contramap(_.value)
 
   implicit def rightWriter[A, B](
-      implicit writer: PBScalarValueWriter[B]): PBScalarValueWriter[Right[A, B]] =
-    writer.contramap(_.b)
+      implicit writer: PBScalarValueWriter[B]
+  ): PBScalarValueWriter[Right[A, B]] =
+    writer.contramap(_.value)
 
 }
 

--- a/src/main/scala/pbdirect/pbIndex.scala
+++ b/src/main/scala/pbdirect/pbIndex.scala
@@ -14,4 +14,4 @@ package pbdirect
  * )
  * }}}
  */
-case class pbIndex(first: Int, more: Int*)
+case class pbIndex(first: Int, more: Int*) extends scala.annotation.Annotation

--- a/src/main/scala/pbdirect/pbUnpacked.scala
+++ b/src/main/scala/pbdirect/pbUnpacked.scala
@@ -17,4 +17,4 @@ package pbdirect
  * This is the standard proto3 behaviour.
  *
  */
-case class pbUnpacked()
+case class pbUnpacked() extends scala.annotation.Annotation

--- a/src/test/scala/pbdirect/PBFieldReaderSpec.scala
+++ b/src/test/scala/pbdirect/PBFieldReaderSpec.scala
@@ -66,11 +66,11 @@ class PBFieldReaderSpec extends AnyWordSpecLike with Matchers {
     }
     "read a Float from Protobuf" in {
       val bytes = Array[Byte](13, -51, -52, 76, 62)
-      PBFieldReader[Float].read(1, bytes) shouldBe 0.2F
+      PBFieldReader[Float].read(1, bytes) shouldBe 0.2f
     }
     "read a Double from Protobuf" in {
       val bytes = Array[Byte](9, -107, 100, 121, -31, 127, -3, -75, 61)
-      PBFieldReader[Double].read(1, bytes) shouldBe 0.00000000002D
+      PBFieldReader[Double].read(1, bytes) shouldBe 0.00000000002d
     }
     "read a String from Protobuf" in {
       val bytes = Array[Byte](10, 5, 72, 101, 108, 108, 111)
@@ -147,12 +147,13 @@ class PBFieldReaderSpec extends AnyWordSpecLike with Matchers {
           @pbIndex(2) service: String,
           @pbIndex(3) node: String,
           @pbIndex(4) value: Float,
-          @pbIndex(5) count: Int)
+          @pbIndex(5) count: Int
+      )
       val bytes = Array[Byte](10, 37, 10, 6, 109, 101, 116, 114, 105, 99, 18, 13, 109, 105, 99, 114,
         111, 115, 101, 114, 118, 105, 99, 101, 115, 26, 4, 110, 111, 100, 101, 37, 0, 0, 64, 65, 40,
         -71, 96)
       PBFieldReader[List[Metric]]
-        .read(1, bytes) shouldBe Metric("metric", "microservices", "node", 12F, 12345) :: Nil
+        .read(1, bytes) shouldBe Metric("metric", "microservices", "node", 12f, 12345) :: Nil
     }
     "use the default value when reading a missing Boolean from Protobuf" in {
       PBFieldReader[Boolean].read(1, Array.empty[Byte]) shouldBe false
@@ -170,7 +171,7 @@ class PBFieldReaderSpec extends AnyWordSpecLike with Matchers {
       PBFieldReader[Long].read(1, Array.empty[Byte]) shouldBe 0L
     }
     "use the default value when reading a missing Float from Protobuf" in {
-      PBFieldReader[Float].read(1, Array.empty[Byte]) shouldBe 0.0F
+      PBFieldReader[Float].read(1, Array.empty[Byte]) shouldBe 0.0f
     }
     "use the default value when reading a missing Double from Protobuf" in {
       PBFieldReader[Double].read(1, Array.empty[Byte]) shouldBe 0.0

--- a/src/test/scala/pbdirect/PBFieldWriterSpec.scala
+++ b/src/test/scala/pbdirect/PBFieldWriterSpec.scala
@@ -11,7 +11,8 @@ import shapeless.tag._
 class PBFieldWriterSpec extends AnyWordSpecLike with Matchers {
 
   def write[A](value: A, flags: Flags = Flags(skipDefaultValue = true, unpacked = false))(
-      implicit writer: PBFieldWriter[A]): Array[Byte] = {
+      implicit writer: PBFieldWriter[A]
+  ): Array[Byte] = {
     val buffer = new ByteArrayOutputStream()
     val out    = CodedOutputStream.newInstance(buffer)
     writer.writeTo(1, value, out, flags)
@@ -70,10 +71,10 @@ class PBFieldWriterSpec extends AnyWordSpecLike with Matchers {
         0, 0, 0, -128, 0, 0, 0, 0)
     }
     "write a Float to Protobuf" in {
-      write(0.2F) shouldBe Array[Byte](13, -51, -52, 76, 62)
+      write(0.2f) shouldBe Array[Byte](13, -51, -52, 76, 62)
     }
     "write a Double to Protobuf" in {
-      write(0.00000000002D) shouldBe Array[Byte](9, -107, 100, 121, -31, 127, -3, -75, 61)
+      write(0.00000000002d) shouldBe Array[Byte](9, -107, 100, 121, -31, 127, -3, -75, 61)
     }
     "write a String to Protobuf" in {
       write("Hello") shouldBe Array[Byte](10, 5, 72, 101, 108, 108, 111)
@@ -167,7 +168,7 @@ class PBFieldWriterSpec extends AnyWordSpecLike with Matchers {
           @pbIndex(4) value: Float,
           @pbIndex(5) count: Int
       )
-      write(Metric("metric", "microservices", "node", 12F, 12345) :: Nil) shouldBe Array[Byte](10,
+      write(Metric("metric", "microservices", "node", 12f, 12345) :: Nil) shouldBe Array[Byte](10,
         37, 10, 6, 109, 101, 116, 114, 105, 99, 18, 13, 109, 105, 99, 114, 111, 115, 101, 114, 118,
         105, 99, 101, 115, 26, 4, 110, 111, 100, 101, 37, 0, 0, 64, 65, 40, -71, 96)
     }

--- a/src/test/scala/pbdirect/PBMessageReaderSpec.scala
+++ b/src/test/scala/pbdirect/PBMessageReaderSpec.scala
@@ -48,7 +48,8 @@ class PBMessageReaderSpec extends AnyWordSpecLike with Matchers {
       case class InnerMessage(@pbIndex(1) value: Option[Int])
       case class OuterMessage(
           @pbIndex(1) text: Option[String],
-          @pbIndex(2) inner: Option[InnerMessage])
+          @pbIndex(2) inner: Option[InnerMessage]
+      )
       val bytes = Array[Byte](10, 5, 72, 101, 108, 108, 111, 18, 2, 8, 11)
       bytes.pbTo[OuterMessage] shouldBe OuterMessage(Some("Hello"), Some(InnerMessage(Some(11))))
     }
@@ -58,10 +59,11 @@ class PBMessageReaderSpec extends AnyWordSpecLike with Matchers {
           @pbIndex(2) service: String,
           @pbIndex(3) node: String,
           @pbIndex(4) value: Float,
-          @pbIndex(5) count: Int)
+          @pbIndex(5) count: Int
+      )
       case class Metrics(@pbIndex(1) metrics: List[Metric])
       val message = Metrics(
-        Metric("metric", "microservices", "node", 12F, 12345) :: Nil
+        Metric("metric", "microservices", "node", 12f, 12345) :: Nil
       )
       val bytes = Array[Byte](10, 37, 10, 6, 109, 101, 116, 114, 105, 99, 18, 13, 109, 105, 99, 114,
         111, 115, 101, 114, 118, 105, 99, 101, 115, 26, 4, 110, 111, 100, 101, 37, 0, 0, 64, 65, 40,

--- a/src/test/scala/pbdirect/PBMessageWriterSpec.scala
+++ b/src/test/scala/pbdirect/PBMessageWriterSpec.scala
@@ -57,7 +57,8 @@ class PBMessageWriterSpec extends AnyWordSpecLike with Matchers {
       case class InnerMessage(@pbIndex(1) value: Option[Int])
       case class OuterMessage(
           @pbIndex(1) text: Option[String],
-          @pbIndex(2) inner: Option[InnerMessage])
+          @pbIndex(2) inner: Option[InnerMessage]
+      )
       val message = OuterMessage(Some("Hello"), Some(InnerMessage(Some(11))))
       message.toPB shouldBe Array[Byte](10, 5, 72, 101, 108, 108, 111, 18, 2, 8, 11)
     }
@@ -65,7 +66,8 @@ class PBMessageWriterSpec extends AnyWordSpecLike with Matchers {
       case class InnerMessage(@pbIndex(1) value: Option[Int])
       case class OuterMessage(
           @pbIndex(1) text: Option[String],
-          @pbIndex(2) inner: Option[InnerMessage])
+          @pbIndex(2) inner: Option[InnerMessage]
+      )
       val message = OuterMessage(Some("Hello"), Some(InnerMessage(None)))
       message.toPB shouldBe Array[Byte](10, 5, 72, 101, 108, 108, 111, 18, 0)
     }
@@ -73,7 +75,8 @@ class PBMessageWriterSpec extends AnyWordSpecLike with Matchers {
       case class InnerMessage(@pbIndex(1) value: Option[Int])
       case class OuterMessage(
           @pbIndex(1) text: Option[String],
-          @pbIndex(2) inner: Option[InnerMessage])
+          @pbIndex(2) inner: Option[InnerMessage]
+      )
       val message = OuterMessage(Some("Hello"), None)
       message.toPB shouldBe Array[Byte](10, 5, 72, 101, 108, 108, 111)
     }
@@ -83,10 +86,11 @@ class PBMessageWriterSpec extends AnyWordSpecLike with Matchers {
           @pbIndex(2) microservice: String,
           @pbIndex(3) node: String,
           @pbIndex(4) value: Float,
-          @pbIndex(5) count: Int)
+          @pbIndex(5) count: Int
+      )
       case class Metrics(@pbIndex(1) metrics: List[Metric])
       val message = Metrics(
-        Metric("metric", "microservices", "node", 12F, 12345) :: Nil
+        Metric("metric", "microservices", "node", 12f, 12345) :: Nil
       )
       message.toPB shouldBe Array[Byte](10, 37, 10, 6, 109, 101, 116, 114, 105, 99, 18, 13, 109,
         105, 99, 114, 111, 115, 101, 114, 118, 105, 99, 101, 115, 26, 4, 110, 111, 100, 101, 37, 0,

--- a/src/test/scala/pbdirect/ProtocComparisonSpec.scala
+++ b/src/test/scala/pbdirect/ProtocComparisonSpec.scala
@@ -1,5 +1,3 @@
-
-
 package pbdirect
 
 import org.scalatest.flatspec._
@@ -171,14 +169,14 @@ object ProtocComparisonSpec {
     def string(x: String): String = {
       val escaped = x
         .replaceAllLiterally("""\""", """\\""") // escape backslashes
-        .replaceAllLiterally("\n", "\\n") // escape newlines and other control characters
+        .replaceAllLiterally("\n", "\\n")       // escape newlines and other control characters
         .replaceAllLiterally("\r", "\\r")
         .replaceAllLiterally("\b", "\\b")
         .replaceAllLiterally("\f", "\\f")
         .replaceAllLiterally("\t", "\\t")
         .replaceAllLiterally("\u0000", "\\0")
         .replaceAllLiterally(""""""", """\"""") // esape double quotes
-      s""""$escaped"""" // wrap in double quotes
+      s""""$escaped""""                         // wrap in double quotes
     }
 
     def stringStringMap(map: Map[String, String]): String = {

--- a/src/test/scala/pbdirect/RoundTripSpec.scala
+++ b/src/test/scala/pbdirect/RoundTripSpec.scala
@@ -146,7 +146,8 @@ trait PBEquivalenceImplicits_1 extends PBEquivalenceImplicits_2 {
     }
 
   def option[A](description: String, defaultValue: A)(
-      implicit equiv: PBEquivalence[A]): PBEquivalence[Option[A]] =
+      implicit equiv: PBEquivalence[A]
+  ): PBEquivalence[Option[A]] =
     instance(description) {
       case (Some(x), None) if equiv.equiv(x, defaultValue) => true
       case (Some(_), None)                                 => false
@@ -160,7 +161,7 @@ trait PBEquivalenceImplicits_1 extends PBEquivalenceImplicits_2 {
   implicit val shortOption: PBEquivalence[Option[Short]]   = option("shortOption", 0.toShort)
   implicit val intOption: PBEquivalence[Option[Int]]       = option("intOption", 0)
   implicit val longOption: PBEquivalence[Option[Long]]     = option("longOption", 0L)
-  implicit val floatOption: PBEquivalence[Option[Float]]   = option("floatOption", 0.0F)
+  implicit val floatOption: PBEquivalence[Option[Float]]   = option("floatOption", 0.0f)
   implicit val doubleOption: PBEquivalence[Option[Double]] = option("doubleOption", 0.0)
   implicit val boolOption: PBEquivalence[Option[Boolean]]  = option("boolOption", false)
   implicit val stringOption: PBEquivalence[Option[String]] = option("stringOption", "")
@@ -171,7 +172,8 @@ trait PBEquivalenceImplicits_1 extends PBEquivalenceImplicits_2 {
 
   implicit def either[A, B](
       implicit aEquiv: PBEquivalence[A],
-      bEquiv: PBEquivalence[B]): PBEquivalence[Either[A, B]] = instance("either") {
+      bEquiv: PBEquivalence[B]
+  ): PBEquivalence[Either[A, B]] = instance("either") {
     case (Left(a1), Left(a2))   => aEquiv.equiv(a1, a2)
     case (Right(b1), Right(b2)) => bEquiv.equiv(b1, b2)
     case _                      => false
@@ -194,7 +196,8 @@ trait PBEquivalenceImplicits_1 extends PBEquivalenceImplicits_2 {
       implicit
       gen: Generic.Aux[A, R],
       fieldEquivs: ZipWith.Aux[R, R, fieldEquivalence.type, FEs],
-      fold: LeftFolder.Aux[FEs, Boolean, conj.type, Boolean]): PBEquivalence[A] =
+      fold: LeftFolder.Aux[FEs, Boolean, conj.type, Boolean]
+  ): PBEquivalence[A] =
     instance("message") {
       case (a1, a2) =>
         val hlist1   = gen.to(a1)


### PR DESCRIPTION
(and apply the formatter)

We can keep Scala 2.11 support if necessary, but I assume it's not required these days.