### PR TITLE
Releases 0.5.0

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.2-SNAPSHOT"
+version in ThisBuild := "0.5.0"


### PR DESCRIPTION
Mainly, this new release is supporting Scala 2.13, and it's removing the cross-compilation with Scala 2.11.